### PR TITLE
Make the memory view scrollable

### DIFF
--- a/packages/cpp-debug/package.json
+++ b/packages/cpp-debug/package.json
@@ -44,6 +44,6 @@
       "backend": "lib/node/cpp-debug-backend-module"
   }],
   "adapters": {
-    "cdt-gdb-vscode": "https://github.com/theia-ide/cdt-gdb-vscode/releases/download/v0.0.61/cdt-gdb-vscode-0.0.61.tgz"
+    "cdt-gdb-vscode": "https://github.com/theia-ide/cdt-gdb-vscode/releases/download/v0.0.89/cdt-gdb-vscode-0.0.89.tgz"
   }
 }

--- a/packages/cpp-debug/src/browser/style/index.css
+++ b/packages/cpp-debug/src/browser/style/index.css
@@ -15,10 +15,24 @@
  ********************************************************************************/
 
 .t-mv-container {
+    display: flex;
+    flex-direction: column;
     align-items: left;
     box-sizing: border-box;
     height: 100%;
     padding: 10px;
+}
+
+.t-mv-container button:focus {
+    border: none; /* Fixes a padding issue when clicking a button */
+}
+
+#t-mv-view-container {
+    flex: 1;
+    overflow: auto;
+}
+#t-mv-view-container:focus {
+    border: none; /* Fixes a padding issue when clicking inside the container */
 }
 
 #t-mv-input-container-seperator {
@@ -93,6 +107,10 @@ table#t-mv-view th {
     font-family: monospace;
     color: var(--theia-ui-font-color0);
     padding-right: 15px;
+}
+
+table#t-mv-view .t-mv-view-row.t-mv-view-row-highlight {
+    border-bottom: 1px var(--theia-border-color2) solid;
 }
 
 table#t-mv-view .t-mv-view-row:hover {


### PR DESCRIPTION
I think we can keep improving this iteratively.

For now it relies on https://github.com/eclipse-cdt/cdt-gdb-adapter/pull/89 to get the support from the debug adapter to add an offset to the query.

Right now this change adds the code to scroll the view using the mouse wheel.