### PR TITLE
updated yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -130,24 +130,24 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@theia/application-manager@0.4.0-next.831ad927":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-0.4.0-next.831ad927.tgz#94827152191119d227da7d3719eb6bd8861b007c"
-  integrity sha512-kD2eFbleHLOQC1YW7C+xsJ2Ie9jm1wvLKD49xJgagEZP9aPE6gsLpOoqeyZCeoHttY9vFVnkB7Ndg37FQJNuag==
+"@theia/application-manager@0.6.0-next.844e686f":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-0.6.0-next.844e686f.tgz#f9c4f4b471d9ea8f2113fafb01f8e9f7da72dd26"
+  integrity sha512-TIAgUWpB4PqE/p0oW+9NKwYBOBFSqu3Co6etS6FiKf2G/wgToIpsXFu9reN/4qV0Kz5poB4B0hlhlWeXy+v9dQ==
   dependencies:
-    "@theia/application-package" "0.4.0-next.831ad927"
+    "@theia/application-package" "0.6.0-next.844e686f"
     "@types/fs-extra" "^4.0.2"
     bunyan "^1.8.10"
     circular-dependency-plugin "^5.0.0"
     copy-webpack-plugin "^4.5.0"
     css-loader "^0.28.1"
-    electron "^2.0.14"
+    electron "^3.1.7"
     electron-rebuild "^1.5.11"
     file-loader "^1.1.11"
     font-awesome-webpack "0.0.5-beta.2"
     fs-extra "^4.0.2"
     ignore-loader "^0.1.2"
-    less "^2.7.2"
+    less "^3.0.3"
     source-map-loader "^0.2.1"
     source-map-support "^0.4.18"
     style-loader "^0.23.1"
@@ -157,10 +157,10 @@
     webpack-cli "2.0.12"
     worker-loader "^1.1.1"
 
-"@theia/application-package@0.4.0-next.831ad927":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.4.0-next.831ad927.tgz#e14e83ff455efda256ccb4826c10f4f6aa452eaf"
-  integrity sha512-SFcEMKXVHnUhQSakuXZh20FCvC5eUxU0BjcJBaCEN6FbGKvqwqHaCeVswfqrxoXlnCZa3WRw0/ipJSAU84HOGQ==
+"@theia/application-package@0.6.0-next.844e686f":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.6.0-next.844e686f.tgz#bebed268c5c56a8f7f5aa1088e32321acbf63fe6"
+  integrity sha512-jE57ZgZCtsAINqUf/oM3tlsqtm9dVZzXBQde0QblXpYGeAv8rgxqlCwBL9Re/P1mpFQHH0lf0tvAknlRRAgC2Q==
   dependencies:
     "@types/fs-extra" "^4.0.2"
     "@types/request" "^2.0.3"
@@ -173,40 +173,40 @@
     semver "^5.4.1"
     write-json-file "^2.2.0"
 
-"@theia/callhierarchy@0.4.0-next.831ad927":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-0.4.0-next.831ad927.tgz#82a01b99c4d7f848a87de55cc33c72f0f5266c26"
-  integrity sha512-CNbkjf/byBeUxRNZJFyoGkr33xs6KDG64S2t9+7r9oGKyYO0e8b2eiGzNklA+X36w7JXtfU5CoJElsb9747XDw==
+"@theia/callhierarchy@0.6.0-next.844e686f":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-0.6.0-next.844e686f.tgz#20d9c634a7260d9ebeb15792d0f1267b6f86496e"
+  integrity sha512-CVIcNWQ6B6/8S2clEiENAZI0PS5CYOnC+zcS0K6uPaQMjeMioepADpZr/XL9eT6Wg4LFl75E0SDa4LhKhNr6DQ==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/editor" "0.4.0-next.831ad927"
-    "@theia/languages" "0.4.0-next.831ad927"
-    "@theia/monaco" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/editor" "0.6.0-next.844e686f"
+    "@theia/languages" "0.6.0-next.844e686f"
+    "@theia/monaco" "0.6.0-next.844e686f"
     ts-md5 "^1.2.2"
 
 "@theia/cli@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-0.4.0-next.831ad927.tgz#49ef7eb38ab9e01f6dd2d67c257ef9019b602b96"
-  integrity sha512-o71kLtPjjce4xKHx58e4dSZfZ12+rtDjkPmpfB97e6k0qW6qNYIaXo2OKVB082C7XdcaXU7W684HgtpoY7oEfA==
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-0.6.0-next.844e686f.tgz#1036e89b3deabdd76eff812e2fa010941c67d075"
+  integrity sha512-ZzTQj8X2M9esLC9+MKs7VHG6zZInUTW/i0hiQ8gB+YnG/nUzP+ciPGHlIu0X2VWZIPvHG9Dcdz5liFZQzcVfbA==
   dependencies:
-    "@theia/application-manager" "0.4.0-next.831ad927"
+    "@theia/application-manager" "0.6.0-next.844e686f"
 
-"@theia/console@0.4.0-next.831ad927":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/console/-/console-0.4.0-next.831ad927.tgz#109ff234d338453411b148de35de0f603f72ca96"
-  integrity sha512-1eXXL+kS0j04K3XczhyzX10RgKxsG193SVrN08UV8pFjRhfMkGbW7+IFa0QJC5s/BXqvXm0AVouurlbH2otBWw==
+"@theia/console@0.6.0-next.844e686f":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/console/-/console-0.6.0-next.844e686f.tgz#5e0af4d8f43ff50efca1f7acdf3e6218acba9755"
+  integrity sha512-xzBOFHlNZ/TSyX4Xa8080E+Z1LOy9h0GbOE2cj5UAWjvG6Dpjx6zu+ycl8pF14yUZpDARldrbgzFPq2JWqotuw==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/monaco" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/monaco" "0.6.0-next.844e686f"
     anser "^1.4.7"
 
-"@theia/core@0.4.0-next.831ad927", "@theia/core@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.4.0-next.831ad927.tgz#78eb744b13f50a85a5335ebf232408c9b5bfc193"
-  integrity sha512-5iU43Yr0uBUJSHNbqMbqF3ICw09Bhch7JgLtmRC2ArITYYthZAjl1a5A1YFmXoAen0e9B9GEzwqVIos6N82qRA==
+"@theia/core@0.6.0-next.844e686f", "@theia/core@next":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.6.0-next.844e686f.tgz#8068e03413fba2b75ce04ea07aaac707478ee866"
+  integrity sha512-QpKGvBNuWF87g7gBPOrfjktnjsBk5+63pPR+ioVBV8EJ+W/O+7z+Cviid5kOMwlWxIajY0oMMWexPymBF9bU7A==
   dependencies:
     "@phosphor/widgets" "^1.5.0"
-    "@theia/application-package" "0.4.0-next.831ad927"
+    "@theia/application-package" "0.6.0-next.844e686f"
     "@types/body-parser" "^1.16.4"
     "@types/bunyan" "^1.8.0"
     "@types/express" "^4.16.0"
@@ -220,7 +220,8 @@
     "@types/yargs" "^11.1.0"
     ajv "^6.5.3"
     body-parser "^1.17.2"
-    electron "^2.0.14"
+    electron "^3.1.7"
+    electron-store "^2.0.0"
     es6-promise "^4.2.4"
     express "^4.16.3"
     file-icons-js "^1.0.3"
@@ -230,6 +231,7 @@
     inversify "^4.14.0"
     lodash.debounce "^4.0.8"
     lodash.throttle "^4.1.1"
+    nsfw "^1.2.2"
     perfect-scrollbar "^1.3.0"
     react "^16.4.1"
     react-dom "^16.4.1"
@@ -238,72 +240,73 @@
     reflect-metadata "^0.1.10"
     route-parser "^0.0.5"
     vscode-languageserver-types "^3.10.0"
-    vscode-nsfw "^1.0.17"
     vscode-uri "^1.0.1"
     vscode-ws-jsonrpc "^0.0.2-1"
     ws "^5.2.2"
     yargs "^11.1.0"
 
 "@theia/cpp@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/cpp/-/cpp-0.4.0-next.831ad927.tgz#1e0c3e4e49948bb592bec2452be240079dfa2358"
-  integrity sha512-9c/1cdsOXLqe129lhegWVmQFzZKCXeKeuJ0EA2oTa7LN3gDPmrmLQd+Q0UXzeATfkm4PBIDK/F9xFkWh2QiiWA==
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/cpp/-/cpp-0.6.0-next.844e686f.tgz#0673fb6a04052c85c8e09c55ae72d89ddc88160f"
+  integrity sha512-zN54ohvaD6wxLJw/FhWW5TLHmeM7x2o+FPe7a5E9yVC8JLhjup4E2BC669OpbzwznVu4c80b4KvSoteyfhdOAw==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/editor" "0.4.0-next.831ad927"
-    "@theia/filesystem" "0.4.0-next.831ad927"
-    "@theia/languages" "0.4.0-next.831ad927"
-    "@theia/monaco" "0.4.0-next.831ad927"
-    "@theia/preferences" "0.4.0-next.831ad927"
-    "@theia/process" "0.4.0-next.831ad927"
-    "@theia/task" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/editor" "0.6.0-next.844e686f"
+    "@theia/filesystem" "0.6.0-next.844e686f"
+    "@theia/languages" "0.6.0-next.844e686f"
+    "@theia/monaco" "0.6.0-next.844e686f"
+    "@theia/preferences" "0.6.0-next.844e686f"
+    "@theia/process" "0.6.0-next.844e686f"
+    "@theia/task" "0.6.0-next.844e686f"
     string-argv "^0.1.1"
 
 "@theia/debug@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/debug/-/debug-0.4.0-next.831ad927.tgz#fcb09860f16cb4cbc49201d01e89aee9684df53a"
-  integrity sha512-UZEEPpzeU/OEiBYjVG1IAYcrt/khnDSnIvEa8U8gyD4M2FFgXjPO06eTXYVwKZM8b8L2d8ZuuH859pzrOsh8Cg==
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/debug/-/debug-0.6.0-next.844e686f.tgz#443678c9b88772625cd4dacbc8b0331d91421055"
+  integrity sha512-ohxU116ghmcjyEKURgOrtlCZQksyodt0KMGUGaVFsPfX80TwOCj3HDaDSo4gNj1l3IwoCIpeOBh6sVmJcuXbvA==
   dependencies:
-    "@theia/console" "0.4.0-next.831ad927"
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/editor" "0.4.0-next.831ad927"
-    "@theia/filesystem" "0.4.0-next.831ad927"
-    "@theia/json" "0.4.0-next.831ad927"
-    "@theia/markers" "0.4.0-next.831ad927"
-    "@theia/monaco" "0.4.0-next.831ad927"
-    "@theia/output" "0.4.0-next.831ad927"
-    "@theia/process" "0.4.0-next.831ad927"
-    "@theia/terminal" "0.4.0-next.831ad927"
-    "@theia/variable-resolver" "0.4.0-next.831ad927"
-    "@theia/workspace" "0.4.0-next.831ad927"
+    "@theia/console" "0.6.0-next.844e686f"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/editor" "0.6.0-next.844e686f"
+    "@theia/filesystem" "0.6.0-next.844e686f"
+    "@theia/json" "0.6.0-next.844e686f"
+    "@theia/markers" "0.6.0-next.844e686f"
+    "@theia/monaco" "0.6.0-next.844e686f"
+    "@theia/output" "0.6.0-next.844e686f"
+    "@theia/process" "0.6.0-next.844e686f"
+    "@theia/terminal" "0.6.0-next.844e686f"
+    "@theia/variable-resolver" "0.6.0-next.844e686f"
+    "@theia/workspace" "0.6.0-next.844e686f"
     "@types/p-debounce" "^1.0.0"
     jsonc-parser "^2.0.2"
     mkdirp "^0.5.0"
     p-debounce "^1.0.0"
+    requestretry "^3.1.0"
     tar "^4.0.0"
     unzip-stream "^0.3.0"
     vscode-debugprotocol "^1.32.0"
     vscode-uri "^1.0.1"
 
-"@theia/editor@0.4.0-next.831ad927", "@theia/editor@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-0.4.0-next.831ad927.tgz#fcb1020f4d1abf4799e349f6ce5d776d57d115d0"
-  integrity sha512-HQDTt4SOVNdU20D+8sMHJRvrwKMGc/T2sCIFxenpSPalZF9PNeXvL071p+sWtdeRdonK2bQvoSKzFebAY1vGmg==
+"@theia/editor@0.6.0-next.844e686f", "@theia/editor@next":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-0.6.0-next.844e686f.tgz#b3f2ecf2999007ed72a1329b0f97e78d52ac1e15"
+  integrity sha512-Sx+MM/LyXgvoJPeH5O/Th2Q4DyYAsIDGCEEoLFOsacpK82v4YYZI+sy0uvbH1GjM33N6WJbd56CaChLPQxmFPQ==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/languages" "0.4.0-next.831ad927"
-    "@theia/variable-resolver" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/languages" "0.6.0-next.844e686f"
+    "@theia/variable-resolver" "0.6.0-next.844e686f"
     "@types/base64-arraybuffer" "0.1.0"
     base64-arraybuffer "^0.1.5"
 
-"@theia/filesystem@0.4.0-next.831ad927", "@theia/filesystem@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-0.4.0-next.831ad927.tgz#79a9c3457f88658d6805a8e45000602614453367"
-  integrity sha512-zGBzThnBWDfQ3q5Ng9KxLemqsJHfl4ZySdiHhuLXB3nf3d/voRnOmAOBgvL004nJcbyR6RJm4QC2dO5w+I8J/w==
+"@theia/filesystem@0.6.0-next.844e686f", "@theia/filesystem@next":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-0.6.0-next.844e686f.tgz#ef1d8be85e3719e721d7a1cbc78f260bbddead01"
+  integrity sha512-jztc4IC2vydFoNAztVZSr3zd3Sl7BjcNzEBdYW5+K1npf3c92eBs694VRnV4YmH+7seoungJ2VmzeDr9JoPmCg==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
     "@types/base64-js" "^1.2.5"
     "@types/body-parser" "^1.17.0"
+    "@types/formidable" "^1.0.31"
     "@types/fs-extra" "^4.0.2"
     "@types/mime-types" "^2.1.0"
     "@types/rimraf" "^2.0.2"
@@ -313,6 +316,7 @@
     base64-js "^1.2.1"
     body-parser "^1.18.3"
     drivelist "^6.4.3"
+    formidable "^1.2.1"
     fs-extra "^4.0.2"
     http-status-codes "^1.3.0"
     mime-types "^2.1.18"
@@ -325,178 +329,188 @@
     uuid "^3.2.1"
     zip-dir "^1.0.2"
 
-"@theia/json@0.4.0-next.831ad927", "@theia/json@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/json/-/json-0.4.0-next.831ad927.tgz#989903e8fc8706655788c7875ccf84ccd006a6d9"
-  integrity sha512-7eLgwcgM1IlzSlDqUzAYD6UY6pPnvsCSdg7uBtBgxi6XAWpVeQQlBYXHmHWikvBTTCrc5TllX3m014sBdpo33g==
+"@theia/json@0.6.0-next.844e686f", "@theia/json@next":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/json/-/json-0.6.0-next.844e686f.tgz#935d912d5cd07953be36ad2b17b5870c3469b79f"
+  integrity sha512-y80aYINZs/m/92cbP8mgEzCAD3txOrjTZyhJNY2TTvAyu+rFtMxqS0QV5OnhZgiG+bIdMgEs9UdtLz75mQDl2g==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/languages" "0.4.0-next.831ad927"
-    "@theia/monaco" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/languages" "0.6.0-next.844e686f"
+    "@theia/monaco" "0.6.0-next.844e686f"
     vscode-json-languageserver "^1.0.1"
 
-"@theia/languages@0.4.0-next.831ad927", "@theia/languages@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-0.4.0-next.831ad927.tgz#191387b30fd1f5b234cf343eb5cb991223cf28f5"
-  integrity sha512-modsgOV7iyTqYYXSEmlufxQUqhCqeE/I7RlsxECNsvSHAlWg0jPG7h8BfxynqlDRWeOcANUq/5MA0oaaQd6toQ==
+"@theia/languages@0.6.0-next.844e686f", "@theia/languages@next":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-0.6.0-next.844e686f.tgz#a28b0c1e2d4838f64cc7ab0b5215d8617cb05a24"
+  integrity sha512-tpWRcyq78jtcTJAmJESlvs204d4Go2y0HszvcQd6yJLyNKD0EOglpOH/3iZxWVQ87AG7TlNPe3HLtrf5aBtCgg==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/output" "0.4.0-next.831ad927"
-    "@theia/process" "0.4.0-next.831ad927"
-    "@theia/workspace" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/output" "0.6.0-next.844e686f"
+    "@theia/process" "0.6.0-next.844e686f"
+    "@theia/workspace" "0.6.0-next.844e686f"
     "@typefox/monaco-editor-core" "^0.14.6"
     "@types/uuid" "^3.4.3"
     monaco-languageclient "^0.9.0"
     uuid "^3.2.1"
 
-"@theia/markers@0.4.0-next.831ad927", "@theia/markers@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-0.4.0-next.831ad927.tgz#62e7d9c50f09d4b35270e44686389b4d7241d5e8"
-  integrity sha512-CZxNQr685ohMaLMra+2qu+yViSnQTG0XxcRdoZThirAZzcwXnK8oXkpKtS2+oXpXoTvW2A77VxKB2Sbk1fSMKg==
+"@theia/markers@0.6.0-next.844e686f", "@theia/markers@next":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-0.6.0-next.844e686f.tgz#1787fc26b56fb0900eed1038d29ab410b5e6fafe"
+  integrity sha512-rHsryien7ptV8cGNAiFh3bZB1SmdJjQW+es2okdiBICZuGf7hb532NERpqgO9tSEdUIQt+NyIFD7v+IUqctt/Q==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/filesystem" "0.4.0-next.831ad927"
-    "@theia/navigator" "0.4.0-next.831ad927"
-    "@theia/workspace" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/filesystem" "0.6.0-next.844e686f"
+    "@theia/navigator" "0.6.0-next.844e686f"
+    "@theia/workspace" "0.6.0-next.844e686f"
 
 "@theia/messages@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-0.4.0-next.831ad927.tgz#be95eb35f0d1465b7f9cdc31fc34a531c82db9e4"
-  integrity sha512-XkqsW654GifWLDxQxo0kbPkJeEhEumQHTuiJC8sy60NpSLOKZQRVlLj1BWkz/pfAUaNAJFkElGY8dw6Ybtq8bw==
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-0.6.0-next.844e686f.tgz#0f81dc422f113e81fb925292fb1106faab550b9a"
+  integrity sha512-UPxgYbhJyrqs2nM2zBP7ppiPTjLYHgRMIZGIQBTt1pWz/fj9jGh8PCJWlNvmfivQ6va88Ci8gZGAv+sOv+EN1A==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
 
-"@theia/monaco@0.4.0-next.831ad927", "@theia/monaco@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-0.4.0-next.831ad927.tgz#ebf7333ce6c27ae7c10a764c47a158794584e896"
-  integrity sha512-jy6iqmAcnmjo210vBdwpsyLzk/X/jINQ2XHj/WKlNU2mMnGbxP38AaKXLbBQ60hkxfwKE8wXjrEJgTSe8LpbPQ==
+"@theia/monaco@0.6.0-next.844e686f", "@theia/monaco@next":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-0.6.0-next.844e686f.tgz#d203ba4e96ea9396bdb0ed43995c58726d09c4d9"
+  integrity sha512-H7dRaGNyNFHexVnwoQfKzBDYwsPgIl6wq1i34O+/rvVM81xvjLquJB+BXpurxUqAsiUx4MknFqwbnA0YT2p+1Q==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/editor" "0.4.0-next.831ad927"
-    "@theia/filesystem" "0.4.0-next.831ad927"
-    "@theia/languages" "0.4.0-next.831ad927"
-    "@theia/markers" "0.4.0-next.831ad927"
-    "@theia/outline-view" "0.4.0-next.831ad927"
-    "@theia/workspace" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/editor" "0.6.0-next.844e686f"
+    "@theia/filesystem" "0.6.0-next.844e686f"
+    "@theia/languages" "0.6.0-next.844e686f"
+    "@theia/markers" "0.6.0-next.844e686f"
+    "@theia/outline-view" "0.6.0-next.844e686f"
+    "@theia/workspace" "0.6.0-next.844e686f"
+    deepmerge "2.0.1"
     jsonc-parser "^2.0.2"
     monaco-css "^2.0.1"
     monaco-html "^2.0.2"
     onigasm "^2.1.0"
     vscode-textmate "^4.0.1"
 
-"@theia/navigator@0.4.0-next.831ad927", "@theia/navigator@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-0.4.0-next.831ad927.tgz#a41a08e000e9688ae6bd732d3df86a80f746c7a2"
-  integrity sha512-4V0oWUvqvtInEE/WO3rQCSWy+RoyJ/TiBHAMFoJEi4fiYq4Ug/mskpChM7kJABSpozgj5U7P5/4u1i5LktdEPQ==
+"@theia/navigator@0.6.0-next.844e686f", "@theia/navigator@next":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-0.6.0-next.844e686f.tgz#6f615ec16a99055d1c8acd37443daddb7288f6c8"
+  integrity sha512-TsYsl8jIY0fpE4WdihPOOX3Q1m5HYBl7d4iA3+K3bvK8vRT/qs1ciqE155O5ghet9tnrmCdMxG/00QDMIbMqrg==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/filesystem" "0.4.0-next.831ad927"
-    "@theia/workspace" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/filesystem" "0.6.0-next.844e686f"
+    "@theia/workspace" "0.6.0-next.844e686f"
     fuzzy "^0.1.3"
     minimatch "^3.0.4"
 
-"@theia/outline-view@0.4.0-next.831ad927":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-0.4.0-next.831ad927.tgz#74df1e80a6173fd8f24da439d4ac791988b56217"
-  integrity sha512-Zp0YA/fTIK/DboiSE1WdqkzG3Hy3+hyA8arypJ2OcPcV+wt/1L8g6BGvj4VhlprQscCgcrozlul3h7a/FtO/aQ==
+"@theia/node-pty@0.7.8-theia004":
+  version "0.7.8-theia004"
+  resolved "https://registry.yarnpkg.com/@theia/node-pty/-/node-pty-0.7.8-theia004.tgz#0fe31b958df9315352d5fbeea7075047cf69c935"
+  integrity sha512-GetaD2p1qVPq/xbNCHCwKYjIr9IWjksf9V2iiv/hV6f885cJ+ie0Osr4+C159PrwzGRYW2jQVUtXghBJoyOCLg==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
+    nan "2.10.0"
 
-"@theia/output@0.4.0-next.831ad927":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/output/-/output-0.4.0-next.831ad927.tgz#89b4626d0054698cc6ee4419fa4a288639b7828b"
-  integrity sha512-uhaMK2LJm5pf1c0elZk+L6v4Wc288Q4P8e7weyy+kwdaypFUW3adknatlftOUhZF7N+Fv9hFUQ3oAkNV1yjUYw==
+"@theia/outline-view@0.6.0-next.844e686f":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-0.6.0-next.844e686f.tgz#eb2e1260baf778dcbfb6bbc8778a51d3d1cd6318"
+  integrity sha512-SSawSz1Bpd17r5ir/bdEmLU9XeQ7dpkKoblkz5jD2NwiMZy8UaiFWdLrE5MZkX8T18F+ThxoTA2aWcbvwJHmOw==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
 
-"@theia/preferences@0.4.0-next.831ad927", "@theia/preferences@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-0.4.0-next.831ad927.tgz#6f9306bd46587d35ae7f4a34b6ff6fe0ae0db032"
-  integrity sha512-csR1W0y6zju6wBhQVTjvlHx5amJGxmbhn5wcuH7yLWyF1qCljuFo4dnYZX08JMtGhWFwXoYJsxeneNIOOJ0Khw==
+"@theia/output@0.6.0-next.844e686f":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/output/-/output-0.6.0-next.844e686f.tgz#4b7f09b92394fc635c59ee2e311b35adebdb6685"
+  integrity sha512-JcHL8U98TwHNRPLrq+aQO3FixS4AujGSTFxNkiO75w7/8Vyjk+8ENrkgjWq8q09LRlSLEq9M8YH+q9BCQ8umHQ==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/editor" "0.4.0-next.831ad927"
-    "@theia/filesystem" "0.4.0-next.831ad927"
-    "@theia/monaco" "0.4.0-next.831ad927"
-    "@theia/userstorage" "0.4.0-next.831ad927"
-    "@theia/workspace" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+
+"@theia/preferences@0.6.0-next.844e686f", "@theia/preferences@next":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-0.6.0-next.844e686f.tgz#576445329424a7bec1c8f3a8db562d64a0c9b019"
+  integrity sha512-lEen08QLAbX0fmP0Lxc/RB4Nv4pk4VwCdUbkl17hE1ltcScVUI0WtBuAg/78LRbGFRzfiKydI7/5ud4j7QWS4Q==
+  dependencies:
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/editor" "0.6.0-next.844e686f"
+    "@theia/filesystem" "0.6.0-next.844e686f"
+    "@theia/json" "0.6.0-next.844e686f"
+    "@theia/monaco" "0.6.0-next.844e686f"
+    "@theia/userstorage" "0.6.0-next.844e686f"
+    "@theia/workspace" "0.6.0-next.844e686f"
     "@types/fs-extra" "^4.0.2"
     fs-extra "^4.0.2"
     jsonc-parser "^2.0.2"
 
-"@theia/process@0.4.0-next.831ad927", "@theia/process@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/process/-/process-0.4.0-next.831ad927.tgz#c58f3a77fe5b65e4702a37b721d5e311d0f7518c"
-  integrity sha512-qS+91evBrLwiiL18O9CBBZaIbT2NnxQ+CTFo6LWOreHvHUmqKMY+g6BTyfaRh/rx2H0VeCfZc/HBGuNYlKxbDA==
+"@theia/process@0.6.0-next.844e686f", "@theia/process@next":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/process/-/process-0.6.0-next.844e686f.tgz#768675c4250eee3084cc532b07d08f14df961fcd"
+  integrity sha512-foWCNPpvdsLLYxZdlSJ9K8r6I6ZtoqUTRmDGmLIkAsK4rEUxKQIwe+32rL6fhgFLE2akrbM/X3ub16nu5+B8eg==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    node-pty "0.7.6"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/node-pty" "0.7.8-theia004"
     string-argv "^0.1.1"
 
-"@theia/task@0.4.0-next.831ad927":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/task/-/task-0.4.0-next.831ad927.tgz#cc56488b98904ded1d45cb6184a7be032d8dab1b"
-  integrity sha512-Caux6uSWH298R43ZyG+nZShl+hW2xZ20MiQKzdC8wY8k/RraGW6Owsfxx3pLZuAapbfQDRzzmDZoLwj6YO1zWA==
+"@theia/task@0.6.0-next.844e686f":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/task/-/task-0.6.0-next.844e686f.tgz#a283d74eaff8bc983aa61ac203aa0512070bfa36"
+  integrity sha512-tYTjG0yXLv1EIOm0oj0Y5jH2I8a4Akc8cV1pnu2KM2f1GjOjBDR1Bw4+vG28dt+ylaIeXUXIYlM5aIcM8m+Yaw==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/filesystem" "0.4.0-next.831ad927"
-    "@theia/markers" "0.4.0-next.831ad927"
-    "@theia/process" "0.4.0-next.831ad927"
-    "@theia/terminal" "0.4.0-next.831ad927"
-    "@theia/variable-resolver" "0.4.0-next.831ad927"
-    "@theia/workspace" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/filesystem" "0.6.0-next.844e686f"
+    "@theia/markers" "0.6.0-next.844e686f"
+    "@theia/process" "0.6.0-next.844e686f"
+    "@theia/terminal" "0.6.0-next.844e686f"
+    "@theia/variable-resolver" "0.6.0-next.844e686f"
+    "@theia/workspace" "0.6.0-next.844e686f"
     jsonc-parser "^2.0.2"
 
-"@theia/terminal@0.4.0-next.831ad927", "@theia/terminal@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-0.4.0-next.831ad927.tgz#37bb5151401adc617d49f905ac986d80d94da8c7"
-  integrity sha512-yf/6jgbr+B0vDkocu+TKcEYuqQraa0lBiAlfIfP+aBYt15VfErUpgPtdUf9ZedSMQ5Xo29esLevPCbmDY37EsQ==
+"@theia/terminal@0.6.0-next.844e686f", "@theia/terminal@next":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-0.6.0-next.844e686f.tgz#702bb919404612f621073a7f5ca20484355ec342"
+  integrity sha512-gNrWG/nsWMCpg0wFFpTlbByGsgc/32Vv2673fnv67eSw6kYOJwvrn0ZVJabIPY6RABE1kCZuwx4nItc3ngE4Lg==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/filesystem" "0.4.0-next.831ad927"
-    "@theia/process" "0.4.0-next.831ad927"
-    "@theia/workspace" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/editor" "0.6.0-next.844e686f"
+    "@theia/filesystem" "0.6.0-next.844e686f"
+    "@theia/process" "0.6.0-next.844e686f"
+    "@theia/workspace" "0.6.0-next.844e686f"
     xterm "3.9.2"
 
 "@theia/typescript@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/typescript/-/typescript-0.4.0-next.831ad927.tgz#bcd500e2824ee6e2e868330432dbf59ea84afaa9"
-  integrity sha512-J9a/TeKzwh4GvgKaf8sT/mwgtokigdUoDvVR3hEankssTKGR+rksq365vKH7+rxMA0N6FPhSi18xo2Q2l+BeoA==
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/typescript/-/typescript-0.6.0-next.844e686f.tgz#113e0be85978475d9a41d46a5c035b024228671d"
+  integrity sha512-K95TQyYrfDcsfRisiJc3p+jlXXIjxoJ3aXkSjkmtpGIjozwtIV349gVNGYSPkdTyuXREb9BMEF+tg9xRaQT2MQ==
   dependencies:
-    "@theia/application-package" "0.4.0-next.831ad927"
-    "@theia/callhierarchy" "0.4.0-next.831ad927"
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/editor" "0.4.0-next.831ad927"
-    "@theia/filesystem" "0.4.0-next.831ad927"
-    "@theia/languages" "0.4.0-next.831ad927"
-    "@theia/monaco" "0.4.0-next.831ad927"
-    "@theia/workspace" "0.4.0-next.831ad927"
+    "@theia/application-package" "0.6.0-next.844e686f"
+    "@theia/callhierarchy" "0.6.0-next.844e686f"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/editor" "0.6.0-next.844e686f"
+    "@theia/filesystem" "0.6.0-next.844e686f"
+    "@theia/languages" "0.6.0-next.844e686f"
+    "@theia/monaco" "0.6.0-next.844e686f"
+    "@theia/workspace" "0.6.0-next.844e686f"
     command-exists "^1.2.8"
     typescript-language-server "^0.3.7"
 
-"@theia/userstorage@0.4.0-next.831ad927":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-0.4.0-next.831ad927.tgz#f8a7e9851824ce61cdfcffec1495ad32ea38a8a7"
-  integrity sha512-Th4xuhVLrPd9emfw5mgGzQlMi46e5XPIffBKC0XVZPaSrPK1fUZkdmzxUvdlbck9EuOX95TVcWN6fjQBIL1b/A==
+"@theia/userstorage@0.6.0-next.844e686f":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-0.6.0-next.844e686f.tgz#8482edb54308f4490cb21a0f3f1aa548a6b55e1b"
+  integrity sha512-iVIzGg/sEolZZKA9viXj2kbZ9J1JcLry2+zTWQLsGnT4vBxh5Yi2kDTOd26XRhsw4cGVGjMhWqpMcbRbMRtahw==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/filesystem" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/filesystem" "0.6.0-next.844e686f"
 
-"@theia/variable-resolver@0.4.0-next.831ad927":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-0.4.0-next.831ad927.tgz#e4c36ebe9a5f2606ee4fb974dc6f6fb95d8918bd"
-  integrity sha512-hYy85bq9kLdAIkQa5vS/KxNBEdVL+q+ULsWHesFBz37A5R5jUa0kdIQOsMaefTkUfxqyVRL8ANufcRJ8jOED7Q==
+"@theia/variable-resolver@0.6.0-next.844e686f":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-0.6.0-next.844e686f.tgz#7d77c73ca6a8b591aeabf1ddec373aa29f4af9e3"
+  integrity sha512-Z3Sspiz430iA47gW//0Yv8OY0j9z8kqMT0/vMJih9yz2IRL3u/C0cZ9HD76YNLBjhKwk7fwhKQssjb+LP8+UIA==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
 
-"@theia/workspace@0.4.0-next.831ad927", "@theia/workspace@next":
-  version "0.4.0-next.831ad927"
-  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-0.4.0-next.831ad927.tgz#8f1bb78294c9453cd2b28f299c86ad74d1fef6ed"
-  integrity sha512-mh7QNAnnGe4h0VrdWlV5PTZQAWLRp7FD3QAoSA8JKoKVcl6JgPfr1RL4s7pBZOlGL9L3dDs2T1SB/EYZpi2e2g==
+"@theia/workspace@0.6.0-next.844e686f", "@theia/workspace@next":
+  version "0.6.0-next.844e686f"
+  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-0.6.0-next.844e686f.tgz#7b814b5163414faa104a92dde7766e86f25240eb"
+  integrity sha512-WC6z8XQ6nnnsp0vafn/glkoHYQHREcWdnnk7ODBnKvU3NG5UCLEixcVFVMaSjmYvEr+78Cystmj5xCNG5eCewg==
   dependencies:
-    "@theia/core" "0.4.0-next.831ad927"
-    "@theia/filesystem" "0.4.0-next.831ad927"
-    "@theia/variable-resolver" "0.4.0-next.831ad927"
+    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/filesystem" "0.6.0-next.844e686f"
+    "@theia/variable-resolver" "0.6.0-next.844e686f"
     "@types/fs-extra" "^4.0.2"
     ajv "^6.5.3"
     fs-extra "^4.0.2"
@@ -575,6 +589,14 @@
   resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.2.1.tgz#ee2b3b8eaa11c0938289953606b745b738c54b1e"
   integrity sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==
   dependencies:
+    "@types/node" "*"
+
+"@types/formidable@^1.0.31":
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/@types/formidable/-/formidable-1.0.31.tgz#274f9dc2d0a1a9ce1feef48c24ca0859e7ec947b"
+  integrity sha512-dIhM5t8lRP0oWe2HF8MuPvdd1TpPTjhDMAqemcq6oIZQCBQTovhBAdTQ5L5veJB4pdQChadmHuxtB0YzqvfU3Q==
+  dependencies:
+    "@types/events" "*"
     "@types/node" "*"
 
 "@types/fs-extra@^4.0.2":
@@ -962,14 +984,6 @@ ajv-keywords@^3.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
   integrity sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
 
-ajv@^4.9.1:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  integrity sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
-
 ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -1175,11 +1189,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-assert-plus@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
-  integrity sha1-104bh+ev/A24qttwIfP+SBAasjQ=
-
 assert@^1.1.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
@@ -1256,17 +1265,12 @@ autoprefixer@^6.3.1:
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
 
-aws-sign2@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
-  integrity sha1-FDQt0428yU0OW4fXY81jYSwOeU8=
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
-aws4@^1.2.1, aws4@^1.8.0:
+aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
@@ -2063,13 +2067,6 @@ body-parser@^1.17.2, body-parser@^1.18.3:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
-boom@2.x.x:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
-  integrity sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=
-  dependencies:
-    hoek "2.x.x"
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2568,7 +2565,7 @@ clone@^1.0.0, clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clone@^2.1.1:
+clone@^2.1.1, clone@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
@@ -2687,7 +2684,7 @@ combined-stream@1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-combined-stream@^1.0.5, combined-stream@~1.0.5, combined-stream@~1.0.6:
+combined-stream@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
   integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
@@ -2756,6 +2753,17 @@ concat-stream@1.6.2, concat-stream@^1.4.10, concat-stream@^1.5.0:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+conf@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/conf/-/conf-2.2.0.tgz#ee282efafc1450b61e205372041ad7d866802d9a"
+  integrity sha512-93Kz74FOMo6aWRVpAZsonOdl2I57jKtHrNmxhumehFQw4X8Sk37SohNY11PG7Q8Okta+UnrVaI006WLeyp8/XA==
+  dependencies:
+    dot-prop "^4.1.0"
+    env-paths "^1.0.0"
+    make-dir "^1.0.0"
+    pkg-up "^2.0.0"
+    write-file-atomic "^2.3.0"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -3076,13 +3084,6 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cryptiles@2.x.x:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
-  integrity sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=
-  dependencies:
-    boom "2.x.x"
-
 crypto-browserify@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
@@ -3273,6 +3274,13 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^3.0.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^3.1.0:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.5.tgz#c2418fbfd7a29f4d4f70ff4cea604d4b64c46407"
@@ -3319,6 +3327,11 @@ deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
+deepmerge@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
+  integrity sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ==
 
 default-shell@^1.0.0:
   version "1.0.1"
@@ -3453,6 +3466,13 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
+dot-prop@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
+  integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
+  dependencies:
+    is-obj "^1.0.0"
+
 drivelist@^6.4.3:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/drivelist/-/drivelist-6.4.3.tgz#b6bf640d26e77ccba2f90c47134bd3b6a34f9709"
@@ -3514,20 +3534,20 @@ ejs@^2.5.9:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
   integrity sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==
 
-electron-download@^3.0.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/electron-download/-/electron-download-3.3.0.tgz#2cfd54d6966c019c4d49ad65fbe65cc9cdef68c8"
-  integrity sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=
+electron-download@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/electron-download/-/electron-download-4.1.1.tgz#02e69556705cc456e520f9e035556ed5a015ebe8"
+  integrity sha512-FjEWG9Jb/ppK/2zToP+U5dds114fM1ZOJqMAR4aXXL5CvyPE9fiqBK/9YcwC9poIFQTEJk/EM/zyRwziziRZrg==
   dependencies:
-    debug "^2.2.0"
-    fs-extra "^0.30.0"
-    home-path "^1.0.1"
+    debug "^3.0.0"
+    env-paths "^1.0.0"
+    fs-extra "^4.0.1"
     minimist "^1.2.0"
-    nugget "^2.0.0"
-    path-exists "^2.1.0"
-    rc "^1.1.2"
-    semver "^5.3.0"
-    sumchecker "^1.2.0"
+    nugget "^2.0.1"
+    path-exists "^3.0.0"
+    rc "^1.2.1"
+    semver "^5.4.1"
+    sumchecker "^2.0.2"
 
 electron-rebuild@^1.5.11:
   version "1.8.2"
@@ -3545,18 +3565,25 @@ electron-rebuild@^1.5.11:
     spawn-rx "^2.0.10"
     yargs "^7.0.2"
 
+electron-store@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-2.0.0.tgz#1035cca2a95409d1f54c7466606345852450d64a"
+  integrity sha512-1WCFYHsYvZBqDsoaS0Relnz0rd81ZkBAI0Fgx7Nq2UWU77rSNs1qxm4S6uH7TCZ0bV3LQpJFk7id/is/ZgoOPA==
+  dependencies:
+    conf "^2.0.0"
+
 electron-to-chromium@^1.2.7:
   version "1.3.72"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.72.tgz#b69683081d5b7eee6e1ea07b2f5fa30b3c72252d"
   integrity sha512-OFbXEC01Lq7A66e3UywkvWYNN00HO1I9MAPereGe0NIXrt2MeaovL1bbY+951HKG0euUdPBe0L7yfKxgqxBMMw==
 
-electron@^2.0.14:
-  version "2.0.15"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.15.tgz#cbba54e0eacb752826dd2364b53e6aa8e7b1e390"
-  integrity sha512-M8/SCXayCIkSdhwfguI0gyH7Ybq+Aj6GElZrFGanC49Q+gTf8DYZJaAeL7GRu6x60Wao5cq3JkwbmH6MNQkRmw==
+electron@^3.1.7:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-3.1.8.tgz#01b0b147dfcca47967ff07dbf72bf5e96125a2ac"
+  integrity sha512-1MiFoMzxGaR0wDfwFE5Ydnuk6ry/4lKgF0c+NFyEItxM/WyEHNZPNjJAeKJ+M/0sevmZ+6W4syNZnQL5M3GgsQ==
   dependencies:
     "@types/node" "^8.0.24"
-    electron-download "^3.0.1"
+    electron-download "^4.1.0"
     extract-zip "^1.0.3"
 
 elegant-spinner@^1.0.1:
@@ -3603,6 +3630,11 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
     memory-fs "^0.4.0"
     tapable "^1.0.0"
 
+env-paths@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
+  integrity sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=
+
 errno@^0.1.1, errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
@@ -3625,7 +3657,7 @@ error@^7.0.2:
     string-template "~0.2.1"
     xtend "~4.0.0"
 
-es6-promise@^4.0.3, es6-promise@^4.0.5, es6-promise@^4.2.4:
+es6-promise@^4.0.3, es6-promise@^4.2.4:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
   integrity sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==
@@ -3868,7 +3900,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.0, extend@~3.0.2:
+extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -4135,15 +4167,6 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@~2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
-  integrity sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.12"
-
 form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
@@ -4152,6 +4175,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
     mime-types "^2.1.12"
+
+formidable@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
+  integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -4182,17 +4210,6 @@ fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
-
-fs-extra@^0.26.5:
-  version "0.26.7"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
-  integrity sha1-muH92UiXeY7at20JGM9C0MMYT6k=
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-    klaw "^1.0.0"
-    path-is-absolute "^1.0.0"
-    rimraf "^2.2.8"
 
 fs-extra@^0.30.0:
   version "0.30.0"
@@ -4587,23 +4604,10 @@ handlebars@^4.0.2:
   optionalDependencies:
     uglify-js "^3.1.4"
 
-har-schema@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
-  integrity sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
-
-har-validator@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
-  integrity sha1-M0gdDxu/9gDdID11gSpqX7oALio=
-  dependencies:
-    ajv "^4.9.1"
-    har-schema "^1.0.5"
 
 har-validator@~5.1.0:
   version "5.1.0"
@@ -4706,16 +4710,6 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hawk@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
-  integrity sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=
-  dependencies:
-    boom "2.x.x"
-    cryptiles "2.x.x"
-    hoek "2.x.x"
-    sntp "1.x.x"
-
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -4725,11 +4719,6 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoek@2.x.x:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
-  integrity sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=
-
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -4737,11 +4726,6 @@ home-or-tmp@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
-
-home-path@^1.0.1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/home-path/-/home-path-1.0.6.tgz#d549dc2465388a7f8667242c5b31588d29af29fc"
-  integrity sha512-wo+yjrdAtoXt43Vy92a+0IPCYViiyLAHyp0QVS4xL/tfvVz5sXIW1ubLZk3nhVkD92fQpUMKX+fzMjr5F489vw==
 
 homedir-polyfill@^1.0.1:
   version "1.0.1"
@@ -4797,15 +4781,6 @@ http-proxy-agent@^2.1.0:
   dependencies:
     agent-base "4"
     debug "3.1.0"
-
-http-signature@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
-  integrity sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=
-  dependencies:
-    assert-plus "^0.2.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -5476,13 +5451,6 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
-json-stable-stringify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
-  dependencies:
-    jsonify "~0.0.0"
-
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -5518,11 +5486,6 @@ jsonfile@^4.0.0:
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -5641,19 +5604,21 @@ less-loader@~2.2.3:
   dependencies:
     loader-utils "^0.2.5"
 
-less@^2.7.2:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/less/-/less-2.7.3.tgz#cc1260f51c900a9ec0d91fb6998139e02507b63b"
-  integrity sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==
+less@^3.0.3:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/less/-/less-3.9.0.tgz#b7511c43f37cf57dc87dffd9883ec121289b1474"
+  integrity sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==
+  dependencies:
+    clone "^2.1.2"
   optionalDependencies:
     errno "^0.1.1"
     graceful-fs "^4.1.2"
     image-size "~0.5.0"
-    mime "^1.2.11"
+    mime "^1.4.1"
     mkdirp "^0.5.0"
     promise "^7.1.1"
-    request "2.81.0"
-    source-map "^0.5.3"
+    request "^2.83.0"
+    source-map "~0.6.0"
 
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
@@ -6090,7 +6055,7 @@ mime-db@~1.36.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
   integrity sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==
 
-mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.18, mime-types@~2.1.19, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.18, mime-types@~2.1.19:
   version "2.1.20"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
   integrity sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==
@@ -6102,7 +6067,7 @@ mime@1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
-mime@^1.2.11:
+mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -6436,20 +6401,6 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-pty@0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.7.6.tgz#bff6148c9c5836ca7e73c7aaaec067dcbdac2f7b"
-  integrity sha512-ECzKUB7KkAFZ0cjyjMXp5WLJ+7YIZ1xnNmiiegOI6WdDaKABUNV5NbB1Dw9MXD4KrZipWII0wQ7RGZ6StU/7jA==
-  dependencies:
-    nan "2.10.0"
-
-nodegit-promise@~4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/nodegit-promise/-/nodegit-promise-4.0.0.tgz#5722b184f2df7327161064a791d2e842c9167b34"
-  integrity sha1-VyKxhPLfcycWEGSnkdLoQskWezQ=
-  dependencies:
-    asap "~2.0.3"
-
 nomnom@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
@@ -6563,7 +6514,17 @@ npm-run-path@^2.0.0:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nugget@^2.0.0:
+nsfw@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/nsfw/-/nsfw-1.2.2.tgz#95b79b6b0e311268aaa20c5c085b9f3b341b0769"
+  integrity sha512-YwoS39dkrp6loO0gvh61UbQPiOYwmbAiKqWSYuMeoSkpxxy8rbe/RVgxIJ1L+ua5usLGr0FPSo7NEQnDQOGyIw==
+  dependencies:
+    fs-extra "^7.0.0"
+    lodash.isinteger "^4.0.4"
+    lodash.isundefined "^3.0.1"
+    nan "^2.0.0"
+
+nugget@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/nugget/-/nugget-2.0.1.tgz#201095a487e1ad36081b3432fa3cada4f8d071b0"
   integrity sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=
@@ -6585,11 +6546,6 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
-
-oauth-sign@~0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
-  integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -6911,7 +6867,7 @@ path-dirname@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
   integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
 
-path-exists@^2.0.0, path-exists@^2.1.0:
+path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
   integrity sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=
@@ -6992,11 +6948,6 @@ perfect-scrollbar@^1.3.0:
   resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.4.0.tgz#5d014ef9775e1f43058a1dbae9ed1daf0e7091f1"
   integrity sha512-/2Sk/khljhdrsamjJYS5NjrH+GKEHEwh7zFSiYyxROyYKagkE4kSn2zDQDRTOMo8mpT2jikxx6yI1dG7lNP/hw==
 
-performance-now@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
-  integrity sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -7028,6 +6979,13 @@ pkg-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+  dependencies:
+    find-up "^2.1.0"
+
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
   dependencies:
     find-up "^2.1.0"
 
@@ -7411,13 +7369,6 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-promisify-node@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/promisify-node/-/promisify-node-0.3.0.tgz#b4b55acf90faa7d2b8b90ca396899086c03060cf"
-  integrity sha1-tLVaz5D6p9K4uQyjlomQhsAwYM8=
-  dependencies:
-    nodegit-promise "~4.0.0"
-
 prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
@@ -7515,11 +7466,6 @@ qs@6.5.2, qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-  integrity sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=
-
 query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
@@ -7601,7 +7547,7 @@ raw-body@2.3.3:
     iconv-lite "0.4.23"
     unpipe "1.0.0"
 
-rc@^1.1.2, rc@^1.1.6, rc@^1.2.7:
+rc@^1.1.6, rc@^1.2.1, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -7941,35 +7887,7 @@ request-light@^0.2.2:
     https-proxy-agent "^2.2.1"
     vscode-nls "^4.0.0"
 
-request@2.81.0:
-  version "2.81.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
-  integrity sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~4.2.1"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    performance-now "^0.2.0"
-    qs "~6.4.0"
-    safe-buffer "^5.0.1"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.0.0"
-
-request@^2.45.0, request@^2.82.0, request@^2.87.0:
+request@^2.45.0, request@^2.82.0, request@^2.83.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -7994,6 +7912,15 @@ request@^2.45.0, request@^2.82.0, request@^2.87.0:
     tough-cookie "~2.4.3"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
+
+requestretry@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/requestretry/-/requestretry-3.1.0.tgz#c8e1976bb946f14889d3604bbad56a01d191c10d"
+  integrity sha512-DkvCPK6qvwxIuVA5TRCvi626WHC2rWjF/n7SCQvVHAr2JX9i1/cmIpSEZlmHAo+c1bj9rjaKoZ9IsKwCpTkoXA==
+  dependencies:
+    extend "^3.0.2"
+    lodash "^4.17.10"
+    when "^3.7.7"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -8405,13 +8332,6 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-sntp@1.x.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
-  integrity sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=
-  dependencies:
-    hoek "2.x.x"
-
 sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
@@ -8472,7 +8392,7 @@ source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -8667,11 +8587,6 @@ string_decoder@~0.10.x:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
   integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
-stringstream@~0.0.4:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
-  integrity sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
-
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -8759,13 +8674,12 @@ style-loader@~0.13.1:
   dependencies:
     loader-utils "^1.0.2"
 
-sumchecker@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-1.3.1.tgz#79bb3b4456dd04f18ebdbc0d703a1d1daec5105d"
-  integrity sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=
+sumchecker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-2.0.2.tgz#0f42c10e5d05da5d42eea3e56c3399a37d6c5b3e"
+  integrity sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=
   dependencies:
     debug "^2.2.0"
-    es6-promise "^4.0.5"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -9006,13 +8920,6 @@ touch@^3.1.0:
   integrity sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==
   dependencies:
     nopt "~1.0.10"
-
-tough-cookie@~2.3.0:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
-  integrity sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
-  dependencies:
-    punycode "^1.4.1"
 
 tough-cookie@~2.4.3:
   version "2.4.3"
@@ -9330,7 +9237,7 @@ uuid@^2.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
   integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -9494,17 +9401,6 @@ vscode-nls@^4.0.0:
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-4.0.0.tgz#4001c8a6caba5cedb23a9c5ce1090395c0e44002"
   integrity sha512-qCfdzcH+0LgQnBpZA53bA32kzp9rpq/f66Som577ObeuDlFIrtbEJ+A/+CCxjIh4G8dpJYNCKIsxpRAHIfsbNw==
 
-vscode-nsfw@^1.0.17:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/vscode-nsfw/-/vscode-nsfw-1.0.17.tgz#da3820f26aea3a7e95cadc54bd9e5dae3d47e474"
-  integrity sha512-FVMu0ax3iftWO9ih5VStiWHFV3NUlfb3H65XIBxY6QpuzWH/J4Hr7WOEuUkZ5/evvQncrYFm088uuuInoUskOg==
-  dependencies:
-    fs-extra "^0.26.5"
-    lodash.isinteger "^4.0.4"
-    lodash.isundefined "^3.0.1"
-    nan "^2.0.0"
-    promisify-node "^0.3.0"
-
 vscode-textmate@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.0.1.tgz#6c36f28e9059ce12bc34907f7a33ea43166b26a8"
@@ -9615,6 +9511,11 @@ webpack@^4.0.0:
     uglifyjs-webpack-plugin "^1.2.4"
     watchpack "^1.5.0"
     webpack-sources "^1.3.0"
+
+when@^3.7.7:
+  version "3.7.8"
+  resolved "https://registry.yarnpkg.com/when/-/when-3.7.8.tgz#c7130b6a7ea04693e842cdc9e7a1f2aa39a39f82"
+  integrity sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I=
 
 whet.extend@~0.9.9:
   version "0.9.9"


### PR DESCRIPTION
so that latest "@theia/*" extensions are pulled

Problem: Following the Theia update to support Node 10.x,
I tried to test if there were impacts on this repo here.
However I noticed that older @theia/* extensions were being
pulled, from a couple of releases ago. I think it's because
we had stepped the "minor" versions vs what was in yarn.lock.
In this case, yarn will not automatically pull the new version
for these packages, as they may be incompatible.

I first attempted to run "yarn upgrade-interactive" to update
the "@theia/*" extensions but it crashed before being done. So
in the end I just removed all references to these extensions
from "yarn.lock" and it did the trick.

Fixes #24

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>