### PR TITLE
Fix broken electron example app

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "dependencies": {
     "@theia/core": "next",
+    "@theia/electron": "next",
     "@theia/filesystem": "next",
     "@theia/workspace": "next",
     "@theia/preferences": "next",
@@ -25,7 +26,7 @@
     "@theia/cli": "next"
   },
   "scripts": {
-    "prepare": "theia build --mode development",    
+    "prepare": "theia build --mode development",
     "start": "theia start",
     "watch": "theia build --watch --mode development"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,6 +113,13 @@
     "@phosphor/signaling" "^1.2.2"
     "@phosphor/virtualdom" "^1.1.2"
 
+"@primer/octicons-react@^9.0.0":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-9.1.1.tgz#bee3d091c6ecc179c5e46d4716929b987b07baf7"
+  integrity sha512-+ZgALoxUOYUeEnqqN6ZqSfRP6LDRgfmErhY4ZIuGlw5Ocjj7AI87J68dD/wYqWl4IW7xE6rmLvpC3kU3iGmAfQ==
+  dependencies:
+    prop-types "^15.6.1"
+
 "@sindresorhus/df@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@sindresorhus/df/-/df-1.0.1.tgz#c69b66f52f6fcdd287c807df210305dbaf78500d"
@@ -130,18 +137,17 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@theia/application-manager@0.6.0-next.844e686f":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-0.6.0-next.844e686f.tgz#f9c4f4b471d9ea8f2113fafb01f8e9f7da72dd26"
-  integrity sha512-TIAgUWpB4PqE/p0oW+9NKwYBOBFSqu3Co6etS6FiKf2G/wgToIpsXFu9reN/4qV0Kz5poB4B0hlhlWeXy+v9dQ==
+"@theia/application-manager@0.9.0-next.1ef5e131":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-0.9.0-next.1ef5e131.tgz#7228fb0463bef9079c981da8dd2daaad9d55b49a"
+  integrity sha512-5XMzpnXRFuHCw+Cwa0+mpNJbuNdFLRBp5rK7ISgygfQmyNOLtj64Ova3NoXGiEbe0+OyYNxJxWHRc1zOdv2iCg==
   dependencies:
-    "@theia/application-package" "0.6.0-next.844e686f"
+    "@theia/application-package" "0.9.0-next.1ef5e131"
     "@types/fs-extra" "^4.0.2"
     bunyan "^1.8.10"
     circular-dependency-plugin "^5.0.0"
     copy-webpack-plugin "^4.5.0"
     css-loader "^0.28.1"
-    electron "^3.1.7"
     electron-rebuild "^1.5.11"
     file-loader "^1.1.11"
     font-awesome-webpack "0.0.5-beta.2"
@@ -157,10 +163,10 @@
     webpack-cli "2.0.12"
     worker-loader "^1.1.1"
 
-"@theia/application-package@0.6.0-next.844e686f":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.6.0-next.844e686f.tgz#bebed268c5c56a8f7f5aa1088e32321acbf63fe6"
-  integrity sha512-jE57ZgZCtsAINqUf/oM3tlsqtm9dVZzXBQde0QblXpYGeAv8rgxqlCwBL9Re/P1mpFQHH0lf0tvAknlRRAgC2Q==
+"@theia/application-package@0.9.0-next.1ef5e131":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.9.0-next.1ef5e131.tgz#b53e82f1a1e5de3fa86722eab6b7d17bd7d5e537"
+  integrity sha512-H38HRiZkSH/+jLsTF/cS6C2E4t9g4J28Nqg7n7YBPoCMczF7DPgA2ztbmomqd8oTzb4/y7b+uNGujEJZcDUaog==
   dependencies:
     "@types/fs-extra" "^4.0.2"
     "@types/request" "^2.0.3"
@@ -173,40 +179,41 @@
     semver "^5.4.1"
     write-json-file "^2.2.0"
 
-"@theia/callhierarchy@0.6.0-next.844e686f":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-0.6.0-next.844e686f.tgz#20d9c634a7260d9ebeb15792d0f1267b6f86496e"
-  integrity sha512-CVIcNWQ6B6/8S2clEiENAZI0PS5CYOnC+zcS0K6uPaQMjeMioepADpZr/XL9eT6Wg4LFl75E0SDa4LhKhNr6DQ==
+"@theia/callhierarchy@0.9.0-next.1ef5e131":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-0.9.0-next.1ef5e131.tgz#684407c19224965a113800cdb3d5bf124ff7fc8d"
+  integrity sha512-GZKS5siRRMYhPXyWi4A6pqXA0s26JAURqH1eSLCMP31wp1BQXUsoTDL7FEYhxa71cSwgGblCOI/U0IiQfJDnmg==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/editor" "0.6.0-next.844e686f"
-    "@theia/languages" "0.6.0-next.844e686f"
-    "@theia/monaco" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/editor" "0.9.0-next.1ef5e131"
+    "@theia/languages" "0.9.0-next.1ef5e131"
+    "@theia/monaco" "0.9.0-next.1ef5e131"
     ts-md5 "^1.2.2"
 
 "@theia/cli@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-0.6.0-next.844e686f.tgz#1036e89b3deabdd76eff812e2fa010941c67d075"
-  integrity sha512-ZzTQj8X2M9esLC9+MKs7VHG6zZInUTW/i0hiQ8gB+YnG/nUzP+ciPGHlIu0X2VWZIPvHG9Dcdz5liFZQzcVfbA==
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-0.9.0-next.1ef5e131.tgz#dd3f82483f1b041337372ca68714a5b3e8a24ce1"
+  integrity sha512-myz2zBgVJcmW7+ecgRah807Psw+5P4qdRCk7GLhPuZiWxBjHC03vfuMhFDxcUwlUWN3cfe745gWzx1GEkFbV1Q==
   dependencies:
-    "@theia/application-manager" "0.6.0-next.844e686f"
+    "@theia/application-manager" "0.9.0-next.1ef5e131"
 
-"@theia/console@0.6.0-next.844e686f":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/console/-/console-0.6.0-next.844e686f.tgz#5e0af4d8f43ff50efca1f7acdf3e6218acba9755"
-  integrity sha512-xzBOFHlNZ/TSyX4Xa8080E+Z1LOy9h0GbOE2cj5UAWjvG6Dpjx6zu+ycl8pF14yUZpDARldrbgzFPq2JWqotuw==
+"@theia/console@0.9.0-next.1ef5e131":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/console/-/console-0.9.0-next.1ef5e131.tgz#ee2c2914182745378d4d96777a8088e19b1eaa07"
+  integrity sha512-e19F77CnhzVvhhf9SHhbXbb+P3hL3C3n5bxO17t1rKaT73tfbEgoDcEOgy4mxPn5JD2G2MTBrHB1Hb4BwTkWvA==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/monaco" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/monaco" "0.9.0-next.1ef5e131"
     anser "^1.4.7"
 
-"@theia/core@0.6.0-next.844e686f", "@theia/core@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.6.0-next.844e686f.tgz#8068e03413fba2b75ce04ea07aaac707478ee866"
-  integrity sha512-QpKGvBNuWF87g7gBPOrfjktnjsBk5+63pPR+ioVBV8EJ+W/O+7z+Cviid5kOMwlWxIajY0oMMWexPymBF9bU7A==
+"@theia/core@0.9.0-next.1ef5e131", "@theia/core@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.9.0-next.1ef5e131.tgz#76d84bf2dd8f44cdcac3349d050ff4884969f265"
+  integrity sha512-vmL4pWK5zOdSV+jsEQuNTTZsRHEjZTR72p2zc6Lnlvti0AhrgIDbNw0MuLZAd7VD5t0V42SIMWF5zblp9hzpaQ==
   dependencies:
     "@phosphor/widgets" "^1.5.0"
-    "@theia/application-package" "0.6.0-next.844e686f"
+    "@primer/octicons-react" "^9.0.0"
+    "@theia/application-package" "0.9.0-next.1ef5e131"
     "@types/body-parser" "^1.16.4"
     "@types/bunyan" "^1.8.0"
     "@types/express" "^4.16.0"
@@ -220,12 +227,9 @@
     "@types/yargs" "^11.1.0"
     ajv "^6.5.3"
     body-parser "^1.17.2"
-    electron "^3.1.7"
-    electron-store "^2.0.0"
     es6-promise "^4.2.4"
     express "^4.16.3"
     file-icons-js "^1.0.3"
-    fix-path "^2.1.0"
     font-awesome "^4.7.0"
     fuzzy "^0.1.3"
     inversify "^4.14.0"
@@ -234,92 +238,102 @@
     nsfw "^1.2.2"
     perfect-scrollbar "^1.3.0"
     react "^16.4.1"
+    react-autosize-textarea "^7.0.0"
     react-dom "^16.4.1"
     react-virtualized "^9.20.0"
     reconnecting-websocket "^3.0.7"
     reflect-metadata "^0.1.10"
     route-parser "^0.0.5"
     vscode-languageserver-types "^3.10.0"
-    vscode-uri "^1.0.1"
+    vscode-uri "^1.0.8"
     vscode-ws-jsonrpc "^0.0.2-1"
     ws "^5.2.2"
     yargs "^11.1.0"
 
 "@theia/cpp@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/cpp/-/cpp-0.6.0-next.844e686f.tgz#0673fb6a04052c85c8e09c55ae72d89ddc88160f"
-  integrity sha512-zN54ohvaD6wxLJw/FhWW5TLHmeM7x2o+FPe7a5E9yVC8JLhjup4E2BC669OpbzwznVu4c80b4KvSoteyfhdOAw==
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/cpp/-/cpp-0.9.0-next.1ef5e131.tgz#7ea3e791633aa20d259c1d343ca576f069e1dfef"
+  integrity sha512-GFCVeFYKwtVhjRx9/9Qnw2Tbj+cLmnBFtwg8UfWFDmCz8GymW5Fgeh/eAf9WGzWMjrolMziRz0lu09oojzcTwQ==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/editor" "0.6.0-next.844e686f"
-    "@theia/filesystem" "0.6.0-next.844e686f"
-    "@theia/languages" "0.6.0-next.844e686f"
-    "@theia/monaco" "0.6.0-next.844e686f"
-    "@theia/preferences" "0.6.0-next.844e686f"
-    "@theia/process" "0.6.0-next.844e686f"
-    "@theia/task" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/editor" "0.9.0-next.1ef5e131"
+    "@theia/filesystem" "0.9.0-next.1ef5e131"
+    "@theia/languages" "0.9.0-next.1ef5e131"
+    "@theia/monaco" "0.9.0-next.1ef5e131"
+    "@theia/preferences" "0.9.0-next.1ef5e131"
+    "@theia/process" "0.9.0-next.1ef5e131"
+    "@theia/task" "0.9.0-next.1ef5e131"
     string-argv "^0.1.1"
 
 "@theia/debug@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/debug/-/debug-0.6.0-next.844e686f.tgz#443678c9b88772625cd4dacbc8b0331d91421055"
-  integrity sha512-ohxU116ghmcjyEKURgOrtlCZQksyodt0KMGUGaVFsPfX80TwOCj3HDaDSo4gNj1l3IwoCIpeOBh6sVmJcuXbvA==
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/debug/-/debug-0.9.0-next.1ef5e131.tgz#eb048a02e7d93d4bbb679dacdedf2d50313a33e4"
+  integrity sha512-raArSrk5qj3ZFpyUCyxgQV313b1XfubpUUCHKOVE0tfX7V3eeJ+iILwal2NXenZOGds5KA1qhsejHKQVNOQM4A==
   dependencies:
-    "@theia/console" "0.6.0-next.844e686f"
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/editor" "0.6.0-next.844e686f"
-    "@theia/filesystem" "0.6.0-next.844e686f"
-    "@theia/json" "0.6.0-next.844e686f"
-    "@theia/markers" "0.6.0-next.844e686f"
-    "@theia/monaco" "0.6.0-next.844e686f"
-    "@theia/output" "0.6.0-next.844e686f"
-    "@theia/process" "0.6.0-next.844e686f"
-    "@theia/terminal" "0.6.0-next.844e686f"
-    "@theia/variable-resolver" "0.6.0-next.844e686f"
-    "@theia/workspace" "0.6.0-next.844e686f"
-    "@types/p-debounce" "^1.0.0"
+    "@theia/console" "0.9.0-next.1ef5e131"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/editor" "0.9.0-next.1ef5e131"
+    "@theia/filesystem" "0.9.0-next.1ef5e131"
+    "@theia/json" "0.9.0-next.1ef5e131"
+    "@theia/markers" "0.9.0-next.1ef5e131"
+    "@theia/monaco" "0.9.0-next.1ef5e131"
+    "@theia/output" "0.9.0-next.1ef5e131"
+    "@theia/preferences" "0.9.0-next.1ef5e131"
+    "@theia/process" "0.9.0-next.1ef5e131"
+    "@theia/terminal" "0.9.0-next.1ef5e131"
+    "@theia/userstorage" "0.9.0-next.1ef5e131"
+    "@theia/variable-resolver" "0.9.0-next.1ef5e131"
+    "@theia/workspace" "0.9.0-next.1ef5e131"
+    "@types/p-debounce" "^1.0.1"
     jsonc-parser "^2.0.2"
     mkdirp "^0.5.0"
-    p-debounce "^1.0.0"
+    p-debounce "^2.1.0"
     requestretry "^3.1.0"
     tar "^4.0.0"
     unzip-stream "^0.3.0"
     vscode-debugprotocol "^1.32.0"
-    vscode-uri "^1.0.1"
 
-"@theia/editor@0.6.0-next.844e686f", "@theia/editor@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-0.6.0-next.844e686f.tgz#b3f2ecf2999007ed72a1329b0f97e78d52ac1e15"
-  integrity sha512-Sx+MM/LyXgvoJPeH5O/Th2Q4DyYAsIDGCEEoLFOsacpK82v4YYZI+sy0uvbH1GjM33N6WJbd56CaChLPQxmFPQ==
+"@theia/editor@0.9.0-next.1ef5e131", "@theia/editor@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-0.9.0-next.1ef5e131.tgz#4c48b9efe4db024fa74554af0232a08a6cca2d02"
+  integrity sha512-nr3wfuxjKDp+y12m/DGiURIysEYuonhRV0SQOG3gFs6fbqzS2vQwrJIJbFM8baFrShBwmIPGaMEsH4PGXmIkHQ==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/languages" "0.6.0-next.844e686f"
-    "@theia/variable-resolver" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/languages" "0.9.0-next.1ef5e131"
+    "@theia/variable-resolver" "0.9.0-next.1ef5e131"
     "@types/base64-arraybuffer" "0.1.0"
     base64-arraybuffer "^0.1.5"
 
-"@theia/filesystem@0.6.0-next.844e686f", "@theia/filesystem@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-0.6.0-next.844e686f.tgz#ef1d8be85e3719e721d7a1cbc78f260bbddead01"
-  integrity sha512-jztc4IC2vydFoNAztVZSr3zd3Sl7BjcNzEBdYW5+K1npf3c92eBs694VRnV4YmH+7seoungJ2VmzeDr9JoPmCg==
+"@theia/electron@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/electron/-/electron-0.9.0-next.1ef5e131.tgz#13441f273081cb49ca20e064269f1b1e147d4388"
+  integrity sha512-44sK5hp8PyCC9RpyvsSXgKdDn2N1iKmsOhkERKqQIWli3Z0vMqeWPSmUd+2S0c1mqI4aA+iEJc/XeUWs3EWyGQ==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@types/base64-js" "^1.2.5"
+    electron "^3.1.7"
+    electron-download "^4.1.1"
+    electron-store "^2.0.0"
+    fix-path "^2.1.0"
+    native-keymap "^1.2.5"
+    node-gyp "^3.6.0"
+    unzipper "^0.9.11"
+    yargs "^11.1.0"
+
+"@theia/filesystem@0.9.0-next.1ef5e131", "@theia/filesystem@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-0.9.0-next.1ef5e131.tgz#e93eb32c5d0b788f8f39e61f07cc4ba5ffe60ac6"
+  integrity sha512-vxhaHwN4T95jYzi7QzEquloYO4y0u1xiTmUqqyZKOzTj1zFhWFRBKYr0fUFmKRvbfzKhThR8Xogz5QFxPTO/Fg==
+  dependencies:
+    "@theia/core" "0.9.0-next.1ef5e131"
     "@types/body-parser" "^1.17.0"
-    "@types/formidable" "^1.0.31"
     "@types/fs-extra" "^4.0.2"
-    "@types/mime-types" "^2.1.0"
     "@types/rimraf" "^2.0.2"
     "@types/tar-fs" "^1.16.1"
     "@types/touch" "0.0.1"
     "@types/uuid" "^3.4.3"
-    base64-js "^1.2.1"
     body-parser "^1.18.3"
     drivelist "^6.4.3"
-    formidable "^1.2.1"
     fs-extra "^4.0.2"
     http-status-codes "^1.3.0"
-    mime-types "^2.1.18"
     minimatch "^3.0.4"
     mv "^2.1.1"
     rimraf "^2.6.2"
@@ -329,74 +343,74 @@
     uuid "^3.2.1"
     zip-dir "^1.0.2"
 
-"@theia/json@0.6.0-next.844e686f", "@theia/json@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/json/-/json-0.6.0-next.844e686f.tgz#935d912d5cd07953be36ad2b17b5870c3469b79f"
-  integrity sha512-y80aYINZs/m/92cbP8mgEzCAD3txOrjTZyhJNY2TTvAyu+rFtMxqS0QV5OnhZgiG+bIdMgEs9UdtLz75mQDl2g==
+"@theia/json@0.9.0-next.1ef5e131", "@theia/json@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/json/-/json-0.9.0-next.1ef5e131.tgz#5603a55e257699e6a9ac04c140d19199455a3875"
+  integrity sha512-jTL73ZBaglXqccxhK0x33eoDz48b2IbxyT+FWDpeMCJiPZx6yCQ/l2ucN5R9sP0Lo5Tuqu/+KPMadnxa5+WPyQ==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/languages" "0.6.0-next.844e686f"
-    "@theia/monaco" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/languages" "0.9.0-next.1ef5e131"
+    "@theia/monaco" "0.9.0-next.1ef5e131"
     vscode-json-languageserver "^1.0.1"
 
-"@theia/languages@0.6.0-next.844e686f", "@theia/languages@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-0.6.0-next.844e686f.tgz#a28b0c1e2d4838f64cc7ab0b5215d8617cb05a24"
-  integrity sha512-tpWRcyq78jtcTJAmJESlvs204d4Go2y0HszvcQd6yJLyNKD0EOglpOH/3iZxWVQ87AG7TlNPe3HLtrf5aBtCgg==
+"@theia/languages@0.9.0-next.1ef5e131", "@theia/languages@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-0.9.0-next.1ef5e131.tgz#c43bad5493a7d3b020b404a6ed2341df5749e536"
+  integrity sha512-DIle/XGHITyxsG59lTESWNKQWjmEENyXBI9soz4ffJx+XBauQj++/95EGIR9c+gWuV33GKw+liPUOFRUNUuLvw==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/output" "0.6.0-next.844e686f"
-    "@theia/process" "0.6.0-next.844e686f"
-    "@theia/workspace" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/output" "0.9.0-next.1ef5e131"
+    "@theia/process" "0.9.0-next.1ef5e131"
+    "@theia/workspace" "0.9.0-next.1ef5e131"
     "@typefox/monaco-editor-core" "^0.14.6"
     "@types/uuid" "^3.4.3"
     monaco-languageclient "^0.9.0"
     uuid "^3.2.1"
 
-"@theia/markers@0.6.0-next.844e686f", "@theia/markers@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-0.6.0-next.844e686f.tgz#1787fc26b56fb0900eed1038d29ab410b5e6fafe"
-  integrity sha512-rHsryien7ptV8cGNAiFh3bZB1SmdJjQW+es2okdiBICZuGf7hb532NERpqgO9tSEdUIQt+NyIFD7v+IUqctt/Q==
+"@theia/markers@0.9.0-next.1ef5e131", "@theia/markers@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-0.9.0-next.1ef5e131.tgz#d515f3f826fc83644211189a337bae4142a7a951"
+  integrity sha512-6vIGlTus7QUz/tXGcb1wFmu6w/rly84Tj1DyAKTH2m7khxL0nB7z1o1/UEv04bg/pscjvVyTMI77d5jgxOpj7w==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/filesystem" "0.6.0-next.844e686f"
-    "@theia/navigator" "0.6.0-next.844e686f"
-    "@theia/workspace" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/filesystem" "0.9.0-next.1ef5e131"
+    "@theia/navigator" "0.9.0-next.1ef5e131"
+    "@theia/workspace" "0.9.0-next.1ef5e131"
 
 "@theia/messages@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-0.6.0-next.844e686f.tgz#0f81dc422f113e81fb925292fb1106faab550b9a"
-  integrity sha512-UPxgYbhJyrqs2nM2zBP7ppiPTjLYHgRMIZGIQBTt1pWz/fj9jGh8PCJWlNvmfivQ6va88Ci8gZGAv+sOv+EN1A==
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-0.9.0-next.1ef5e131.tgz#41d320242a45ced9ab6ded8096bccec6056dcb5c"
+  integrity sha512-GYtk96pWmneItaWFqh4cnj6Bwi2arJxv7VcW2vp9BBdunPNS1ukrKdOVrcaO51wAVO9F8rgNT+D3bVw/S8kg5g==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
 
-"@theia/monaco@0.6.0-next.844e686f", "@theia/monaco@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-0.6.0-next.844e686f.tgz#d203ba4e96ea9396bdb0ed43995c58726d09c4d9"
-  integrity sha512-H7dRaGNyNFHexVnwoQfKzBDYwsPgIl6wq1i34O+/rvVM81xvjLquJB+BXpurxUqAsiUx4MknFqwbnA0YT2p+1Q==
+"@theia/monaco@0.9.0-next.1ef5e131", "@theia/monaco@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-0.9.0-next.1ef5e131.tgz#a922ebf062acbfc760ab5e62ebeffd86c4707196"
+  integrity sha512-/VFVbVuLAfxRMZxi2jqT4JEX6DJJgEe2tRGElemqvVavDiDxr9/ZhA9hv+ts5hk3pOErpw3jFW5bnfl49axNKQ==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/editor" "0.6.0-next.844e686f"
-    "@theia/filesystem" "0.6.0-next.844e686f"
-    "@theia/languages" "0.6.0-next.844e686f"
-    "@theia/markers" "0.6.0-next.844e686f"
-    "@theia/outline-view" "0.6.0-next.844e686f"
-    "@theia/workspace" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/editor" "0.9.0-next.1ef5e131"
+    "@theia/filesystem" "0.9.0-next.1ef5e131"
+    "@theia/languages" "0.9.0-next.1ef5e131"
+    "@theia/markers" "0.9.0-next.1ef5e131"
+    "@theia/outline-view" "0.9.0-next.1ef5e131"
+    "@theia/workspace" "0.9.0-next.1ef5e131"
     deepmerge "2.0.1"
     jsonc-parser "^2.0.2"
     monaco-css "^2.0.1"
     monaco-html "^2.0.2"
-    onigasm "^2.1.0"
+    onigasm "2.2.1"
     vscode-textmate "^4.0.1"
 
-"@theia/navigator@0.6.0-next.844e686f", "@theia/navigator@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-0.6.0-next.844e686f.tgz#6f615ec16a99055d1c8acd37443daddb7288f6c8"
-  integrity sha512-TsYsl8jIY0fpE4WdihPOOX3Q1m5HYBl7d4iA3+K3bvK8vRT/qs1ciqE155O5ghet9tnrmCdMxG/00QDMIbMqrg==
+"@theia/navigator@0.9.0-next.1ef5e131", "@theia/navigator@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-0.9.0-next.1ef5e131.tgz#15bc95db10a863157d8a662c14a9b1e56abcdbb2"
+  integrity sha512-LE81Y/4cB521NNHhLR+eUVlV5j95bAMV8zqsdfn5bO6K5SYxxbZ/AkjyCqY8icdo3SzylPE+sYdmegVO4ENgkg==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/filesystem" "0.6.0-next.844e686f"
-    "@theia/workspace" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/filesystem" "0.9.0-next.1ef5e131"
+    "@theia/workspace" "0.9.0-next.1ef5e131"
     fuzzy "^0.1.3"
     minimatch "^3.0.4"
 
@@ -407,110 +421,112 @@
   dependencies:
     nan "2.10.0"
 
-"@theia/outline-view@0.6.0-next.844e686f":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-0.6.0-next.844e686f.tgz#eb2e1260baf778dcbfb6bbc8778a51d3d1cd6318"
-  integrity sha512-SSawSz1Bpd17r5ir/bdEmLU9XeQ7dpkKoblkz5jD2NwiMZy8UaiFWdLrE5MZkX8T18F+ThxoTA2aWcbvwJHmOw==
+"@theia/outline-view@0.9.0-next.1ef5e131":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-0.9.0-next.1ef5e131.tgz#b740fa17932653ff6cca9bae55426747300a5a10"
+  integrity sha512-Z40e5jweq8M0oGQfEFsz/Zeu0WXDDC9S+bLegZdppAjdc6SlRHEVe5qdlQpuuwim+40Afvm1B62sjdzvj9htSg==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
 
-"@theia/output@0.6.0-next.844e686f":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/output/-/output-0.6.0-next.844e686f.tgz#4b7f09b92394fc635c59ee2e311b35adebdb6685"
-  integrity sha512-JcHL8U98TwHNRPLrq+aQO3FixS4AujGSTFxNkiO75w7/8Vyjk+8ENrkgjWq8q09LRlSLEq9M8YH+q9BCQ8umHQ==
+"@theia/output@0.9.0-next.1ef5e131":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/output/-/output-0.9.0-next.1ef5e131.tgz#9cba70b46b36705095bb3c8f81bd65da12ee4311"
+  integrity sha512-zEChXj/cTINPiZkVzNh0FWt+T2Lfcc0MgaBstY8ZU6FFrr4VTj6MRsh5hhHB1MM0GwNeG5EVh2/5xbi+c7GZSg==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
 
-"@theia/preferences@0.6.0-next.844e686f", "@theia/preferences@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-0.6.0-next.844e686f.tgz#576445329424a7bec1c8f3a8db562d64a0c9b019"
-  integrity sha512-lEen08QLAbX0fmP0Lxc/RB4Nv4pk4VwCdUbkl17hE1ltcScVUI0WtBuAg/78LRbGFRzfiKydI7/5ud4j7QWS4Q==
+"@theia/preferences@0.9.0-next.1ef5e131", "@theia/preferences@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-0.9.0-next.1ef5e131.tgz#7dc37be156b61074346d1abf8e9cc71f41da13aa"
+  integrity sha512-jg0Mv9Ak2lrRA5209dkLWwYkYmiPT+6CMGeWqglnK/tWXSR0BhSpfN/Cg6OKolcAQkIBou2okmtLTw2/y5c+FQ==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/editor" "0.6.0-next.844e686f"
-    "@theia/filesystem" "0.6.0-next.844e686f"
-    "@theia/json" "0.6.0-next.844e686f"
-    "@theia/monaco" "0.6.0-next.844e686f"
-    "@theia/userstorage" "0.6.0-next.844e686f"
-    "@theia/workspace" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/editor" "0.9.0-next.1ef5e131"
+    "@theia/filesystem" "0.9.0-next.1ef5e131"
+    "@theia/json" "0.9.0-next.1ef5e131"
+    "@theia/monaco" "0.9.0-next.1ef5e131"
+    "@theia/userstorage" "0.9.0-next.1ef5e131"
+    "@theia/workspace" "0.9.0-next.1ef5e131"
     "@types/fs-extra" "^4.0.2"
     fs-extra "^4.0.2"
     jsonc-parser "^2.0.2"
 
-"@theia/process@0.6.0-next.844e686f", "@theia/process@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/process/-/process-0.6.0-next.844e686f.tgz#768675c4250eee3084cc532b07d08f14df961fcd"
-  integrity sha512-foWCNPpvdsLLYxZdlSJ9K8r6I6ZtoqUTRmDGmLIkAsK4rEUxKQIwe+32rL6fhgFLE2akrbM/X3ub16nu5+B8eg==
+"@theia/process@0.9.0-next.1ef5e131", "@theia/process@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/process/-/process-0.9.0-next.1ef5e131.tgz#1df50b868b5a3077437ddc2725e9f6791197dbda"
+  integrity sha512-Vh8R63DI8qAfrt3cfNaiGWPnLvkf4OQ+VizJ38MoJDNIgiFP9J/c1HYm/+55QHjJUrfr+N1WC5hsgliHYVZBCQ==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
     "@theia/node-pty" "0.7.8-theia004"
     string-argv "^0.1.1"
 
-"@theia/task@0.6.0-next.844e686f":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/task/-/task-0.6.0-next.844e686f.tgz#a283d74eaff8bc983aa61ac203aa0512070bfa36"
-  integrity sha512-tYTjG0yXLv1EIOm0oj0Y5jH2I8a4Akc8cV1pnu2KM2f1GjOjBDR1Bw4+vG28dt+ylaIeXUXIYlM5aIcM8m+Yaw==
+"@theia/task@0.9.0-next.1ef5e131":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/task/-/task-0.9.0-next.1ef5e131.tgz#1addaaa019e9278f8ee6aae218058a4449b48dbf"
+  integrity sha512-/LI5G4cRmqZubL80zBH93EnH5Skz78HeFauTtsAtsAfAQDG5padPt467y+L9hgVU7+62/XmQDt+znVCduTMISg==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/filesystem" "0.6.0-next.844e686f"
-    "@theia/markers" "0.6.0-next.844e686f"
-    "@theia/process" "0.6.0-next.844e686f"
-    "@theia/terminal" "0.6.0-next.844e686f"
-    "@theia/variable-resolver" "0.6.0-next.844e686f"
-    "@theia/workspace" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/filesystem" "0.9.0-next.1ef5e131"
+    "@theia/markers" "0.9.0-next.1ef5e131"
+    "@theia/monaco" "0.9.0-next.1ef5e131"
+    "@theia/process" "0.9.0-next.1ef5e131"
+    "@theia/terminal" "0.9.0-next.1ef5e131"
+    "@theia/variable-resolver" "0.9.0-next.1ef5e131"
+    "@theia/workspace" "0.9.0-next.1ef5e131"
     jsonc-parser "^2.0.2"
+    vscode-uri "^1.0.8"
 
-"@theia/terminal@0.6.0-next.844e686f", "@theia/terminal@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-0.6.0-next.844e686f.tgz#702bb919404612f621073a7f5ca20484355ec342"
-  integrity sha512-gNrWG/nsWMCpg0wFFpTlbByGsgc/32Vv2673fnv67eSw6kYOJwvrn0ZVJabIPY6RABE1kCZuwx4nItc3ngE4Lg==
+"@theia/terminal@0.9.0-next.1ef5e131", "@theia/terminal@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-0.9.0-next.1ef5e131.tgz#57599ef0cc12a86e8dda2f70ec28cfd44d4e9713"
+  integrity sha512-MVvvzMJNb0QvyYNJL+SALbGDFDMfW1Cm/qP3VrkFYpeYcF2rwfrRFZjo7bDX1qd36bOC2Ss5iwphPyFvHscbEg==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/editor" "0.6.0-next.844e686f"
-    "@theia/filesystem" "0.6.0-next.844e686f"
-    "@theia/process" "0.6.0-next.844e686f"
-    "@theia/workspace" "0.6.0-next.844e686f"
-    xterm "3.9.2"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/editor" "0.9.0-next.1ef5e131"
+    "@theia/filesystem" "0.9.0-next.1ef5e131"
+    "@theia/process" "0.9.0-next.1ef5e131"
+    "@theia/workspace" "0.9.0-next.1ef5e131"
+    xterm "3.13.0"
 
 "@theia/typescript@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/typescript/-/typescript-0.6.0-next.844e686f.tgz#113e0be85978475d9a41d46a5c035b024228671d"
-  integrity sha512-K95TQyYrfDcsfRisiJc3p+jlXXIjxoJ3aXkSjkmtpGIjozwtIV349gVNGYSPkdTyuXREb9BMEF+tg9xRaQT2MQ==
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/typescript/-/typescript-0.9.0-next.1ef5e131.tgz#ab19de0e03c366d709f2c2325c48a9f4919aaed3"
+  integrity sha512-2uJc8sjRA4TFUKsYFNmlTeOGREJQPOwoufBoczqXWvDytajVw1HXZR/Bd80fPMAtsXYMrufu6n1hSQRmbMUz5g==
   dependencies:
-    "@theia/application-package" "0.6.0-next.844e686f"
-    "@theia/callhierarchy" "0.6.0-next.844e686f"
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/editor" "0.6.0-next.844e686f"
-    "@theia/filesystem" "0.6.0-next.844e686f"
-    "@theia/languages" "0.6.0-next.844e686f"
-    "@theia/monaco" "0.6.0-next.844e686f"
-    "@theia/workspace" "0.6.0-next.844e686f"
+    "@theia/application-package" "0.9.0-next.1ef5e131"
+    "@theia/callhierarchy" "0.9.0-next.1ef5e131"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/editor" "0.9.0-next.1ef5e131"
+    "@theia/filesystem" "0.9.0-next.1ef5e131"
+    "@theia/languages" "0.9.0-next.1ef5e131"
+    "@theia/monaco" "0.9.0-next.1ef5e131"
+    "@theia/workspace" "0.9.0-next.1ef5e131"
     command-exists "^1.2.8"
-    typescript-language-server "^0.3.7"
+    typescript-language-server "^0.3.8"
 
-"@theia/userstorage@0.6.0-next.844e686f":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-0.6.0-next.844e686f.tgz#8482edb54308f4490cb21a0f3f1aa548a6b55e1b"
-  integrity sha512-iVIzGg/sEolZZKA9viXj2kbZ9J1JcLry2+zTWQLsGnT4vBxh5Yi2kDTOd26XRhsw4cGVGjMhWqpMcbRbMRtahw==
+"@theia/userstorage@0.9.0-next.1ef5e131":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-0.9.0-next.1ef5e131.tgz#da14ac75b8c002ca3344b03a3bbf44ce5359e571"
+  integrity sha512-KVo3xbe6ta5trL5TvVVxzKleyCLXKkTjgFVKJLTTAX0v+jpZerCpqirLBIL6c4A6OwfQvdav+EZuv0zbQ1uRCw==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/filesystem" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/filesystem" "0.9.0-next.1ef5e131"
 
-"@theia/variable-resolver@0.6.0-next.844e686f":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-0.6.0-next.844e686f.tgz#7d77c73ca6a8b591aeabf1ddec373aa29f4af9e3"
-  integrity sha512-Z3Sspiz430iA47gW//0Yv8OY0j9z8kqMT0/vMJih9yz2IRL3u/C0cZ9HD76YNLBjhKwk7fwhKQssjb+LP8+UIA==
+"@theia/variable-resolver@0.9.0-next.1ef5e131":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-0.9.0-next.1ef5e131.tgz#f5aba107858c1135e8f33511bb2ab70f088f263d"
+  integrity sha512-a3tJRQA4XeGlhjfgU3cRjVZA6fjH0C5BocUIxai/jt2twFlT7IcAKX/TfMtxWKj5n/QzShe7H49G2CnnOxosMg==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
 
-"@theia/workspace@0.6.0-next.844e686f", "@theia/workspace@next":
-  version "0.6.0-next.844e686f"
-  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-0.6.0-next.844e686f.tgz#7b814b5163414faa104a92dde7766e86f25240eb"
-  integrity sha512-WC6z8XQ6nnnsp0vafn/glkoHYQHREcWdnnk7ODBnKvU3NG5UCLEixcVFVMaSjmYvEr+78Cystmj5xCNG5eCewg==
+"@theia/workspace@0.9.0-next.1ef5e131", "@theia/workspace@next":
+  version "0.9.0-next.1ef5e131"
+  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-0.9.0-next.1ef5e131.tgz#c6b7cd8da11d3e3be068b5c3b7b6925d924286a2"
+  integrity sha512-8kNDSXIbOMyZY8iwtz8dnMbOEfKWplCtZR5a69d+WBxl4TM6TLJfO3ety0kcjKjdiKeK+CuK46hfoSDn16e9Bg==
   dependencies:
-    "@theia/core" "0.6.0-next.844e686f"
-    "@theia/filesystem" "0.6.0-next.844e686f"
-    "@theia/variable-resolver" "0.6.0-next.844e686f"
+    "@theia/core" "0.9.0-next.1ef5e131"
+    "@theia/filesystem" "0.9.0-next.1ef5e131"
+    "@theia/variable-resolver" "0.9.0-next.1ef5e131"
     "@types/fs-extra" "^4.0.2"
     ajv "^6.5.3"
     fs-extra "^4.0.2"
@@ -527,11 +543,6 @@
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@types/base64-arraybuffer/-/base64-arraybuffer-0.1.0.tgz#739eea0a974d13ae831f96d97d882ceb0b187543"
   integrity sha512-oyV0CGER7tX6OlfnLfGze0XbsA7tfRuTtsQ2JbP8K5KBUzc24yoYRD+0XjMRQgOejvZWeIbtkNaHlE8akzj4aQ==
-
-"@types/base64-js@^1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@types/base64-js/-/base64-js-1.2.5.tgz#582b2476169a6cba460a214d476c744441d873d5"
-  integrity sha1-WCskdhaabLpGCiFNR2x0REHYc9U=
 
 "@types/body-parser@*", "@types/body-parser@^1.16.4", "@types/body-parser@^1.17.0":
   version "1.17.0"
@@ -591,14 +602,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/formidable@^1.0.31":
-  version "1.0.31"
-  resolved "https://registry.yarnpkg.com/@types/formidable/-/formidable-1.0.31.tgz#274f9dc2d0a1a9ce1feef48c24ca0859e7ec947b"
-  integrity sha512-dIhM5t8lRP0oWe2HF8MuPvdd1TpPTjhDMAqemcq6oIZQCBQTovhBAdTQ5L5veJB4pdQChadmHuxtB0YzqvfU3Q==
-  dependencies:
-    "@types/events" "*"
-    "@types/node" "*"
-
 "@types/fs-extra@^4.0.2":
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.8.tgz#6957ddaf9173195199cb96da3db44c74700463d2"
@@ -634,11 +637,6 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
   integrity sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg==
 
-"@types/mime-types@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.0.tgz#9ca52cda363f699c69466c2a6ccdaad913ea7a73"
-  integrity sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=
-
 "@types/mime@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
@@ -655,14 +653,16 @@
   integrity sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==
 
 "@types/node@^8.0.24":
-  version "8.10.30"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.30.tgz#2c82cbed5f79d72280c131d2acffa88fbd8dd353"
-  integrity sha512-Le8HGMI5gjFSBqcCuKP/wfHC19oURzkU2D+ERIescUoJd+CmNEMYBib9LQ4zj1HHEZOJQWhw2ZTnbD8weASh/Q==
+  version "8.10.50"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.50.tgz#f3d68482b1f54b5f4fba8daaac385db12bb6a706"
+  integrity sha512-+ZbcUwJdaBgOZpwXeT0v+gHC/jQbEfzoc9s4d0rN0JIKeQbuTrT+A2n1aQY6LpZjrLXJT7avVUqiCecCJeeZxA==
 
-"@types/p-debounce@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/p-debounce/-/p-debounce-1.0.0.tgz#c7fab3d61f9bc6454337c4aef0dec069456d00ee"
-  integrity sha512-TsMyvtY4cSHdh+gyQp+z4G188PuMg2zMg2AJPUjnbCCM6pEWO4UPvl0aV1Nk2bAfxU0vKl+2LTyFcU6edJIeKw==
+"@types/p-debounce@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/p-debounce/-/p-debounce-1.0.1.tgz#c9956067a240dffedf2682a24d0712ffa5e3c8fe"
+  integrity sha512-zlAn04fH4cGYPAjmYW8Tst/vxn78IJmD3PVMxxBnl3IYAG+9aGKWCu/311fPHnePJMwyxGeOhi63neSiSgM+iw==
+  dependencies:
+    p-debounce "*"
 
 "@types/prop-types@*":
   version "15.5.6"
@@ -1044,12 +1044,17 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
   integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
-ansi-styles@^3.2.1:
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -1264,6 +1269,11 @@ autoprefixer@^6.3.1:
     num2fraction "^1.2.2"
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
+
+autosize@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/autosize/-/autosize-4.0.2.tgz#073cfd07c8bf45da4b9fd153437f5bafbba1e4c9"
+  integrity sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -1957,7 +1967,7 @@ base64-arraybuffer@^0.1.5:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
   integrity sha1-c5JncZI7Whl0etZmqlzUv5xunOg=
 
-base64-js@^1.0.2, base64-js@^1.2.1:
+base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
@@ -1982,6 +1992,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big-integer@^1.6.17:
+  version "1.6.44"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.44.tgz#4ee9ae5f5839fc11ade338fea216b4513454a539"
+  integrity sha512-7MzElZPTyJ2fNvBkPxtFQ2fWIkVmuzw41+BZHSzpEq3ymB2MfeKp1+yXl/tS75xCx+WnyV+yb0kp+K1C3UNwmQ==
+
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
@@ -1992,7 +2007,7 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz#c2d780f53d45bba8317a8902d4ceeaf3a6385b14"
   integrity sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==
 
-binary@^0.3.0:
+binary@^0.3.0, binary@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
   integrity sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=
@@ -2029,6 +2044,11 @@ bluebird@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
   integrity sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==
+
+bluebird@~3.4.1:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
+  integrity sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
@@ -2195,6 +2215,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+buffer-indexof-polyfill@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz#a9fb806ce8145d5428510ce72f278bb363a638bf"
+  integrity sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8=
+
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -2318,15 +2343,15 @@ camelcase@^2.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
   integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
 
-camelcase@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
-  integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
-
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+
+camelcase@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-api@^1.5.2:
   version "1.6.1"
@@ -2370,6 +2395,15 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.2, chalk@^2.4
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -2428,6 +2462,11 @@ chownr@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
   integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
+
+chownr@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
+  integrity sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==
 
 chrome-trace-event@^1.0.0:
   version "1.0.0"
@@ -2495,10 +2534,10 @@ cli-spinners@^0.1.2:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
   integrity sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=
 
-cli-spinners@^1.0.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
-  integrity sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==
+cli-spinners@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.2.0.tgz#e8b988d9206c692302d8ee834e7a85c0144d8f77"
+  integrity sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==
 
 cli-table@^0.3.1:
   version "0.3.1"
@@ -2537,6 +2576,15 @@ cliui@^4.0.0:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
+
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
 
 clone-buffer@^1.0.0:
   version "1.0.0"
@@ -2659,10 +2707,15 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.1.2, colors@^1.2.0:
+colors@^1.1.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.2.tgz#2df8ff573dfbf255af562f8ce7181d6b971a359b"
   integrity sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==
+
+colors@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
+  integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
 
 colors@~1.1.2:
   version "1.1.2"
@@ -2738,6 +2791,11 @@ component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
+
+computed-style@~0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/computed-style/-/computed-style-0.1.4.tgz#7f344fd8584b2e425bedca4a1afc0e300bb05d74"
+  integrity sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ=
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -3260,7 +3318,7 @@ dateformat@^3.0.0, dateformat@^3.0.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@2.6.9, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.5.1, debug@^2.6.3, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.5.1, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -3288,6 +3346,13 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@~0.8.0:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-0.8.1.tgz#20ff4d26f5e422cb68a1bacbbb61039ad8c1c130"
@@ -3301,7 +3366,7 @@ decamelize-keys@^1.0.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -3491,6 +3556,13 @@ dtrace-provider@~0.8:
   dependencies:
     nan "^2.10.0"
 
+duplexer2@~0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
+  integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
+  dependencies:
+    readable-stream "^2.0.2"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -3534,7 +3606,7 @@ ejs@^2.5.9:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
   integrity sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==
 
-electron-download@^4.1.0:
+electron-download@^4.1.0, electron-download@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/electron-download/-/electron-download-4.1.1.tgz#02e69556705cc456e520f9e035556ed5a015ebe8"
   integrity sha512-FjEWG9Jb/ppK/2zToP+U5dds114fM1ZOJqMAR4aXXL5CvyPE9fiqBK/9YcwC9poIFQTEJk/EM/zyRwziziRZrg==
@@ -3550,20 +3622,19 @@ electron-download@^4.1.0:
     sumchecker "^2.0.2"
 
 electron-rebuild@^1.5.11:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/electron-rebuild/-/electron-rebuild-1.8.2.tgz#bfffba64da78e1b403cb79d5150cfa3336645140"
-  integrity sha512-EeR4dgb6NN7ybxduUWMeeLhU/EuF+FzwFZJfMJXD0bx96K+ttAieCXOn9lTO5nA9Qn3hiS7pEpk8pZ9StpGgSg==
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/electron-rebuild/-/electron-rebuild-1.8.5.tgz#d15d0aa7f2151eb3f2935a596a92c0348984ba55"
+  integrity sha512-gDwRA3utfiPnFwBZ1z8M4SEMwsdsy6Bg4VGO2ohelMOIO0vxiCrDQ/FVdLk3h2g7fLb06QFUsQU+86jiTSmZxw==
   dependencies:
-    colors "^1.2.0"
-    debug "^2.6.3"
+    colors "^1.3.3"
+    debug "^4.1.1"
     detect-libc "^1.0.3"
-    fs-extra "^3.0.1"
-    node-abi "^2.0.0"
-    node-gyp "^3.6.0"
-    ora "^1.2.0"
-    rimraf "^2.6.1"
-    spawn-rx "^2.0.10"
-    yargs "^7.0.2"
+    fs-extra "^7.0.1"
+    node-abi "^2.8.0"
+    node-gyp "^4.0.0"
+    ora "^3.4.0"
+    spawn-rx "^3.0.0"
+    yargs "^13.2.2"
 
 electron-store@^2.0.0:
   version "2.0.0"
@@ -3573,14 +3644,14 @@ electron-store@^2.0.0:
     conf "^2.0.0"
 
 electron-to-chromium@^1.2.7:
-  version "1.3.72"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.72.tgz#b69683081d5b7eee6e1ea07b2f5fa30b3c72252d"
-  integrity sha512-OFbXEC01Lq7A66e3UywkvWYNN00HO1I9MAPereGe0NIXrt2MeaovL1bbY+951HKG0euUdPBe0L7yfKxgqxBMMw==
+  version "1.3.191"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.191.tgz#c451b422cd8b2eab84dedabab5abcae1eaefb6f0"
+  integrity sha512-jasjtY5RUy/TOyiUYM2fb4BDaPZfm6CXRFeJDMfFsXYADGxUN49RBqtgB7EL2RmJXeIRUk9lM1U6A5yk2YJMPQ==
 
 electron@^3.1.7:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-3.1.8.tgz#01b0b147dfcca47967ff07dbf72bf5e96125a2ac"
-  integrity sha512-1MiFoMzxGaR0wDfwFE5Ydnuk6ry/4lKgF0c+NFyEItxM/WyEHNZPNjJAeKJ+M/0sevmZ+6W4syNZnQL5M3GgsQ==
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-3.1.7.tgz#2041031db272e88f167b2e5fe2de9eecabcf4632"
+  integrity sha512-rvmucnAsB4hQVdD0fOd1ad7+5u/BX1ak6emcSyPsLUk6rTqvVfOMk5ryC19h7Yd/5X8NWvCGkgYzSyQbgAJngA==
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^4.1.0"
@@ -3603,6 +3674,11 @@ elliptic@^6.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -3799,6 +3875,19 @@ execa@^0.8.0:
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
     is-stream "^1.1.0"
     npm-run-path "^2.0.0"
     p-finally "^1.0.0"
@@ -4104,6 +4193,13 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 first-chunk-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz#1bdecdb8e083c0664b91945581577a43a9f31d70"
@@ -4176,11 +4272,6 @@ form-data@~2.3.2:
     combined-stream "1.0.6"
     mime-types "^2.1.12"
 
-formidable@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
-  integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
-
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
@@ -4222,15 +4313,6 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
-  integrity sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^3.0.0"
-    universalify "^0.1.0"
-
 fs-extra@^4.0.1, fs-extra@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
@@ -4244,6 +4326,15 @@ fs-extra@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
   integrity sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -4289,6 +4380,16 @@ fstream@^1.0.0, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+fstream@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -4317,6 +4418,11 @@ get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
+
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-pkg-repo@^1.0.0:
   version "1.4.0"
@@ -4351,6 +4457,13 @@ get-stream@^2.2.0:
   dependencies:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
+
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -5010,6 +5123,11 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
+invert-kv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
+  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
 ipaddr.js@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
@@ -5473,13 +5591,6 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonfile@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
-  integrity sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -5554,6 +5665,13 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+lcid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
+  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
+  dependencies:
+    invert-kv "^2.0.0"
+
 lerna@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.4.0.tgz#7b76446b154bafb9cba8996f3dc233f1cb6ca7c3"
@@ -5619,6 +5737,18 @@ less@^3.0.3:
     promise "^7.1.1"
     request "^2.83.0"
     source-map "~0.6.0"
+
+line-height@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/line-height/-/line-height-0.3.1.tgz#4b1205edde182872a5efa3c8f620b3187a9c54c9"
+  integrity sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=
+  dependencies:
+    computed-style "~0.1.3"
+
+listenercount@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/listenercount/-/listenercount-1.0.1.tgz#84c8a72ab59c4725321480c975e6508342e70937"
+  integrity sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=
 
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
@@ -5745,6 +5875,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -5817,7 +5955,7 @@ log-symbols@^1.0.2:
   dependencies:
     chalk "^1.0.0"
 
-log-symbols@^2.1.0, log-symbols@^2.2.0:
+log-symbols@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
@@ -5832,7 +5970,7 @@ log-update@^1.0.2:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5871,6 +6009,13 @@ make-dir@^1.0.0, make-dir@^1.1.0:
   integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
   dependencies:
     pify "^3.0.0"
+
+map-age-cleaner@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -5949,6 +6094,15 @@ mem@^1.1.0:
   integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
   dependencies:
     mimic-fn "^1.0.0"
+
+mem@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
+  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
+  dependencies:
+    map-age-cleaner "^0.1.1"
+    mimic-fn "^2.0.0"
+    p-is-promise "^2.0.0"
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -6055,7 +6209,7 @@ mime-db@~1.36.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
   integrity sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==
 
-mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.18, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
   version "2.1.20"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
   integrity sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==
@@ -6081,6 +6235,11 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
+mimic-fn@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 mimic-response@^1.0.0:
   version "1.0.1"
@@ -6140,10 +6299,25 @@ minipass@^2.2.1, minipass@^2.3.3:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^2.3.5:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
+  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minizlib@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
   integrity sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==
+  dependencies:
+    minipass "^2.2.1"
+
+minizlib@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
+  integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
 
@@ -6290,6 +6464,11 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+native-keymap@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/native-keymap/-/native-keymap-1.2.6.tgz#93d1b4c4ae0e9136bc14538cafe02c0bbe95bebf"
+  integrity sha512-8hEr6wNkb7OmGPFLFk1cAsnOt2Y3F4mtBffr8uOyX0kKOjr2JVetSt9TKjk0xyJw/B/HcEgMhXmjFKzGN+9JjA==
+
 ncp@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
@@ -6319,17 +6498,17 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-abi@^2.0.0:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.4.4.tgz#410d8968809fe616dc078a181c44a370912f12fd"
-  integrity sha512-DQ9Mo2mf/XectC+s6+grPPRQ1Z9gI3ZbrGv6nyXRkjwT3HrE0xvtvrfnH7YHYBLgC/KLadg+h3XHnhZw1sv88A==
-  dependencies:
-    semver "^5.4.1"
-
 node-abi@^2.2.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.5.0.tgz#942e1a78bce764bc0c1672d5821e492b9d032052"
   integrity sha512-9g2twBGSP6wIR5PW7tXvAWnEWKJDH/VskdXp168xsw9VVxpEGov8K4jsP4/VeoC7b2ZAyzckvMCuQuQlw44lXg==
+  dependencies:
+    semver "^5.4.1"
+
+node-abi@^2.8.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.9.0.tgz#ae4075b298dab2d92dd1e22c48ccc7ffd7f06200"
+  integrity sha512-jmEOvv0eanWjhX8dX1pmjb7oJl1U1oR4FOh0b2GnvALwSYoOdU7sj+kLDSAyjo4pfC9aj/IxkloxdLJQhSSQBA==
   dependencies:
     semver "^5.4.1"
 
@@ -6354,6 +6533,23 @@ node-gyp@^3.6.0:
     rimraf "2"
     semver "~5.3.0"
     tar "^2.0.0"
+    which "1"
+
+node-gyp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-4.0.0.tgz#972654af4e5dd0cd2a19081b4b46fe0442ba6f45"
+  integrity sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==
+  dependencies:
+    glob "^7.0.3"
+    graceful-fs "^4.1.2"
+    mkdirp "^0.5.0"
+    nopt "2 || 3"
+    npmlog "0 || 1 || 2 || 3 || 4"
+    osenv "0"
+    request "^2.87.0"
+    rimraf "2"
+    semver "~5.3.0"
+    tar "^4.4.8"
     which "1"
 
 node-libs-browser@^2.0.0:
@@ -6619,7 +6815,7 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-onigasm@^2.1.0:
+onigasm@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.1.tgz#d56da809d63d3bb25510e8b8e447ffe98e56bebb"
   integrity sha512-pa361CpVfsWOk0MQ1jLuJ1GvEJMHEHgZmaBpOIfBbvbp2crkDHacXB6mA4vgEfO7fL0OEMUSuZjX0Q9yTx6jTg==
@@ -6651,15 +6847,17 @@ ora@^0.2.3:
     cli-spinners "^0.1.2"
     object-assign "^4.0.1"
 
-ora@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-1.4.0.tgz#884458215b3a5d4097592285f93321bb7a79e2e5"
-  integrity sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==
+ora@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-3.4.0.tgz#bf0752491059a3ef3ed4c85097531de9fdbcd318"
+  integrity sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==
   dependencies:
-    chalk "^2.1.0"
+    chalk "^2.4.2"
     cli-cursor "^2.1.0"
-    cli-spinners "^1.0.1"
-    log-symbols "^2.1.0"
+    cli-spinners "^2.0.0"
+    log-symbols "^2.2.0"
+    strip-ansi "^5.2.0"
+    wcwidth "^1.0.1"
 
 os-browserify@^0.3.0:
   version "0.3.0"
@@ -6671,13 +6869,6 @@ os-homedir@^1.0.0, os-homedir@^1.0.1:
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
-os-locale@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
-  integrity sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=
-  dependencies:
-    lcid "^1.0.0"
-
 os-locale@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
@@ -6686,6 +6877,15 @@ os-locale@^2.0.0:
     execa "^0.7.0"
     lcid "^1.0.0"
     mem "^1.1.0"
+
+os-locale@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
+  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
+  dependencies:
+    execa "^1.0.0"
+    lcid "^2.0.0"
+    mem "^4.0.0"
 
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -6710,10 +6910,20 @@ p-cancelable@^0.4.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
   integrity sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==
 
+p-debounce@*, p-debounce@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-debounce/-/p-debounce-2.1.0.tgz#e79f70c6e325cbb9bddbcbec0b81025084671ad3"
+  integrity sha512-M9bMt62TTnozdZhqFgs+V7XD2MnuKCaz+7fZdlu2/T7xruI3uIE5CicQ0vx1hV7HIUYF0jF+4/R1AgfOkl74Qw==
+
 p-debounce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-debounce/-/p-debounce-1.0.0.tgz#cb7f2cbeefd87a09eba861e112b67527e621e2fd"
   integrity sha1-y38svu/YegnrqGHhErZ1J+Yh4v0=
+
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
 p-each-series@^1.0.0:
   version "1.0.0"
@@ -6732,6 +6942,11 @@ p-is-promise@^1.1.0:
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
   integrity sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=
 
+p-is-promise@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
+  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
+
 p-lazy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-lazy/-/p-lazy-1.0.0.tgz#ec53c802f2ee3ac28f166cc82d0b2b02de27a835"
@@ -6744,12 +6959,26 @@ p-limit@^1.0.0, p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
 
 p-map@^1.1.1, p-map@^1.2.0:
   version "1.2.0"
@@ -6779,6 +7008,11 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 pako@~1.0.2, pako@~1.0.5:
   version "1.0.6"
@@ -7369,6 +7603,15 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.6, prop-types@^15.6.1:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
@@ -7423,6 +7666,14 @@ pump@^2.0.0, pump@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
   integrity sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
@@ -7557,6 +7808,15 @@ rc@^1.1.6, rc@^1.2.1, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-autosize-textarea@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-7.0.0.tgz#4f633e4238de7ba73c1da8fdc307353c50f1c5ab"
+  integrity sha512-rGQLpGUaELvzy3NKzp0kkcppaUtZTptsyR0PGuLotaJDjwRbT0DpD000yCzETpXseJQ/eMsyVGDDHXjXP93u8w==
+  dependencies:
+    autosize "^4.0.2"
+    line-height "^0.3.1"
+    prop-types "^15.5.6"
+
 react-dom@^16.4.1:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.2.tgz#b69ee47aa20bab5327b2b9d7c1fe2a30f2cfa9d7"
@@ -7566,6 +7826,11 @@ react-dom@^16.4.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     schedule "^0.5.0"
+
+react-is@^16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -7660,7 +7925,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -7932,6 +8197,11 @@ require-main-filename@^1.0.1:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -8057,7 +8327,7 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
   integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-rxjs@^5.1.1, rxjs@^5.4.2, rxjs@^5.5.2:
+rxjs@^5.4.2, rxjs@^5.5.2:
   version "5.5.12"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
   integrity sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==
@@ -8068,6 +8338,13 @@ rxjs@^6.1.0:
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
   integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.3.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
+  integrity sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==
   dependencies:
     tslib "^1.9.0"
 
@@ -8201,7 +8478,7 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4:
+setimmediate@^1.0.4, setimmediate@~1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -8397,14 +8674,14 @@ source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-spawn-rx@^2.0.10:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/spawn-rx/-/spawn-rx-2.0.12.tgz#b6285294499426089beea0c3c1ec32d7fc57a376"
-  integrity sha512-gOPXiQQFQ9lTOLuys0iMn3jfxxv9c7zzwhbYLOEbQGvEShHVJ5sSR1oD3Daj88os7jKArDYT7rbOKdvNhe7iEg==
+spawn-rx@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spawn-rx/-/spawn-rx-3.0.0.tgz#1d33511e13ec26337da51d78630e08beb57a6767"
+  integrity sha512-dw4Ryg/KMNfkKa5ezAR5aZe9wNwPdKlnHEXtHOjVnyEDSPQyOpIPPRtcIiu7127SmtHhaCjw21yC43HliW0iIg==
   dependencies:
     debug "^2.5.1"
     lodash.assign "^4.2.0"
-    rxjs "^5.1.1"
+    rxjs "^6.3.1"
 
 spdx-correct@^3.0.0:
   version "3.0.1"
@@ -8558,7 +8835,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=
 
-string-width@^1.0.1, string-width@^1.0.2:
+string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
@@ -8574,6 +8851,15 @@ string-width@^1.0.1, string-width@^1.0.2:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^3.0.0, string-width@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
 
 string_decoder@^1.0.0, string_decoder@~1.1.1:
   version "1.1.1"
@@ -8600,6 +8886,13 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-ansi@~0.1.0:
   version "0.1.1"
@@ -8772,6 +9065,19 @@ tar@^4, tar@^4.0.0:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
+
+tar@^4.4.8:
+  version "4.4.10"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
+  integrity sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.5"
+    minizlib "^1.2.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.3"
 
 temp-dir@^1.0.0:
   version "1.0.0"
@@ -9009,10 +9315,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript-language-server@^0.3.7:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/typescript-language-server/-/typescript-language-server-0.3.7.tgz#ca4c28c1b9b4b9e6f9a60514ba059865ea5e48ef"
-  integrity sha512-26VcyfcMGjojsQv0/uDG8ZxUOhCbH6wNZR1buajQv5hZYxNSqiCm+9InMPjozatECpyfphqVc0rc58q3B+dMfw==
+typescript-language-server@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/typescript-language-server/-/typescript-language-server-0.3.8.tgz#de69db5a4d96b3cd1e994d37a8981010237f6c00"
+  integrity sha512-ohi+libVtaJ0F8asuXeqYlrPV84AkbcpWsp5kBeO6XnCrilwQS+elDrJ+jPu2tfVy3CIUpUbUYUmg4Bq3CA/XQ==
   dependencies:
     command-exists "1.2.6"
     commander "^2.11.0"
@@ -9142,6 +9448,21 @@ unzip-stream@^0.3.0:
   dependencies:
     binary "^0.3.0"
     mkdirp "^0.5.1"
+
+unzipper@^0.9.11:
+  version "0.9.15"
+  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.9.15.tgz#97d99203dad17698ee39882483c14e4845c7549c"
+  integrity sha512-2aaUvO4RAeHDvOCuEtth7jrHFaCKTSXPqUkXwADaLBzGbgZGzUDccoEdJ5lW+3RmfpOZYNx0Rw6F6PUzM6caIA==
+  dependencies:
+    big-integer "^1.6.17"
+    binary "~0.3.0"
+    bluebird "~3.4.1"
+    buffer-indexof-polyfill "~1.0.0"
+    duplexer2 "~0.1.4"
+    fstream "^1.0.12"
+    listenercount "~1.0.1"
+    readable-stream "~2.3.6"
+    setimmediate "~1.0.4"
 
 upath@^1.0.5:
   version "1.1.0"
@@ -9408,10 +9729,15 @@ vscode-textmate@^4.0.1:
   dependencies:
     oniguruma "^7.0.0"
 
-vscode-uri@^1.0.1, vscode-uri@^1.0.3, vscode-uri@^1.0.5, vscode-uri@^1.0.6:
+vscode-uri@^1.0.3, vscode-uri@^1.0.5, vscode-uri@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.6.tgz#6b8f141b0bbc44ad7b07e94f82f168ac7608ad4d"
   integrity sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==
+
+vscode-uri@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
+  integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
 
 vscode-ws-jsonrpc@^0.0.2-1:
   version "0.0.2-2"
@@ -9429,7 +9755,7 @@ watchpack@^1.5.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
-wcwidth@^1.0.0:
+wcwidth@^1.0.0, wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
@@ -9522,11 +9848,6 @@ whet.extend@~0.9.9:
   resolved "https://registry.yarnpkg.com/whet.extend/-/whet.extend-0.9.9.tgz#f877d5bf648c97e5aa542fadc16d6a259b9c11a1"
   integrity sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=
 
-which-module@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
-  integrity sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=
-
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
@@ -9578,6 +9899,15 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
 
 wrappy@1:
   version "1.0.2"
@@ -9659,10 +9989,10 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-xterm@3.9.2:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.9.2.tgz#e94bfbb84217b19bc1c16ed43d303b8245c9313d"
-  integrity sha512-fpQJQFTosY97EK4eB7UOrlFAwwqv1rSqlXgttEVD0S1v4MlevsUkRwrM/ew5X73jQXc+vdglRtccIhcXg5wtGg==
+xterm@3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.13.0.tgz#d0e06c3cf4c1f079aa83f646948457db3b04220b"
+  integrity sha512-FZVmvkkbkky3zldJ2NNOZ9h8jirtbGTlF4sIKMDrejR4wPsVZ3o4F++DQVkdeZqjAwtNOMoR17PMSOTZ+h070g==
 
 y18n@^3.2.1:
   version "3.2.1"
@@ -9684,12 +10014,18 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
   integrity sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=
 
-yargs-parser@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
-  integrity sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=
+yallist@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+yargs-parser@^13.1.0:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
+  integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
   dependencies:
-    camelcase "^3.0.0"
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs-parser@^7.0.0:
   version "7.0.0"
@@ -9723,24 +10059,22 @@ yargs@^11.0.0, yargs@^11.1.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-yargs@^7.0.2:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
-  integrity sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=
+yargs@^13.2.2:
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.2.4.tgz#0b562b794016eb9651b98bd37acf364aa5d6dc83"
+  integrity sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==
   dependencies:
-    camelcase "^3.0.0"
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    get-caller-file "^1.0.1"
-    os-locale "^1.4.0"
-    read-pkg-up "^1.0.1"
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    os-locale "^3.1.0"
     require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
+    require-main-filename "^2.0.0"
     set-blocking "^2.0.0"
-    string-width "^1.0.2"
-    which-module "^1.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^5.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.0"
 
 yargs@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
Fixes #28

Updated the `@theia` dependencies since there were incompatible changes regarding the refactoring of the `@theia/electron` package out of `@theia/core`.

Added peer dependency to `@theia/electron` when building the electron example app so it can
be succesfully run.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>