### PR TITLE
Add 'launch frontend' debug launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,6 +55,16 @@
             "smartStep": true,
             "internalConsoleOptions": "openOnSessionStart",
             "outputCapture": "std"
-        }
+        },
+        {
+          "name": "Launch Frontend",
+          "type": "chrome",
+          "request": "launch",
+          "url": "http://localhost:3000/",
+          "webRoot": "${workspaceRoot}",
+          "sourceMapPathOverrides": {
+            "*": "${webRoot}/*"
+          }
+        },
     ]
 }


### PR DESCRIPTION
Fixes #36

- added a `launch frontend` VSCode debug launch config
in order to launch the frontend in a debug session.
This allows developers to easily debug the provided example
application and troubleshoot problems and bugs.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>